### PR TITLE
Support for multiple SSH keys

### DIFF
--- a/src/core/app/routes/host.py
+++ b/src/core/app/routes/host.py
@@ -17,6 +17,7 @@
 
 #!/usr/bin/env python
 import os
+import dataclasses
 from uuid import UUID
 from app.patch import ensure_uuid
 import paramiko
@@ -213,14 +214,6 @@ def api_delete_host(host_id):
     return {'state': 'SUCCESS'}
 
 
-def getSSHPubKey():
-    try:
-        pubkey = shell.os_popen('cat /root/.ssh/id_rsa.pub')
-        return {'state': 'SUCCESS', 'info': {'public_key': pubkey}}
-    except Exception as e:
-        raise ValueError('Unable to retrieve appliance public key')
-
-
 @app.post("/api/v1/hosts", status_code=201)
 def create_host(item: items_create_host, identity: Json = Depends(auth.valid_token)):
     return api_create_host(item)
@@ -266,4 +259,7 @@ def init_host_ssh_connection(host_id, item: items_connect_host, identity: Json =
 
 @app.get("/api/v1/publickeys", status_code=200)
 def list_ssh_public_keys(identity: Json = Depends(auth.valid_token)):
-    return getSSHPubKey()
+    try:
+        return {'state': 'SUCCESS', 'info': list(map(dataclasses.asdict, ssh.list_public_keys()))}
+    except Exception as e:
+        raise ValueError('Unable to retrieve appliance public key')

--- a/src/core/app/shell.py
+++ b/src/core/app/shell.py
@@ -14,6 +14,7 @@ def os_system(command, check=True):
 
 
 def os_popen(command):
+    # TODO Add check ?
     print(f"[os_popen] {command}")
     return os.popen(command).read()
 

--- a/src/core/app/ssh.py
+++ b/src/core/app/ssh.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from dataclasses import dataclass
+from pathlib import Path
 # SSH Module Imports
 import paramiko
 import select
@@ -22,6 +24,7 @@ import select
 from fastapi.encoders import jsonable_encoder
 from sqlmodel import Session, select
 from app.patch import ensure_uuid
+from app import shell
 # Misc
 import os
 from re import search
@@ -29,6 +32,21 @@ from re import search
 from app import database
 from app.database import Hosts
 from app.routes import host
+
+
+@dataclass
+class SshPublicKey:
+    name: str
+    full_line: str
+
+
+def list_public_keys() -> list[SshPublicKey]:
+    return list(map(
+        lambda path: SshPublicKey(
+            Path(path).stem.removeprefix("id_"),
+            shell.os_popen(f"cat {path}").strip()
+        ),
+        filter(None, shell.os_popen('find /root/.ssh/*.pub').split("\n"))))
 
 
 def init_ssh_connection(host_id, ip_address, username):

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -43,11 +43,11 @@
           <template #cell(actions)="{ rowIndex }">
             <va-button-group gradient :rounded="false">
               <va-button v-if="!$store.state.resources.hostList[rowIndex].ssh" icon="link"
-                @click="selectedHost = $store.state.resources.hostList[rowIndex], showConnectModal = !showConnectModal" />
+                @click="selectedHost = $store.state.resources.hostList[rowIndex], showConnectModal = true" />
               <va-button icon="settings"
                 @click="this.$router.push(`/admin/resources/hypervisors/${$store.state.resources.hostList[rowIndex].id}`)" />
               <va-button icon="delete"
-                @click="selectedHost = $store.state.resources.hostList[rowIndex], showDeleteModal = !showDeleteModal" />
+                @click="selectedHost = $store.state.resources.hostList[rowIndex], showDeleteModal = true" />
             </va-button-group>
           </template>
         </va-data-table>
@@ -57,18 +57,20 @@
       </va-card-content>
     </va-card>
     <va-modal v-model="showConnectModal" size="large" hide-default-actions>
-      <va-form ref="form" @validation="validation = $event, connectHost()">
+      <template #header>
         <h2>
           <va-icon name="link" />
           Connecting to the hypervisor at {{ selectedHost.hostname }}
         </h2>
-        <hr class="mb-4">
+      </template>
+      <hr class="mb-4">
+      <va-form ref="form" @validation="validation = $event, connectHost()">
         <va-input label="Specify the user on the server" messages="The user must have the access rights to KVM."
-          v-model="user" type="text" :rules="[value => value?.length > 0 || 'Field is required']" class="mb-3" />
+          v-model="user" type="text" :rules="[value => value?.trim().length > 0 || 'Field is required']" class="mb-3" />
         <va-tabs v-model="currentTabKey">
           <template #tabs>
             <va-tab v-for="{ name } in sshKeys" :key="name" :name="name">
-              {{ name }}
+              {{ name.toUpperCase() }}
             </va-tab>
           </template>
           <div style="position: relative;">
@@ -80,12 +82,12 @@
           </div>
         </va-tabs>
         <div class="d-flex">
-          <va-button flat @click="showConnectModal = !showConnectModal">
+          <va-button flat @click="showConnectModal = false">
             Cancel
           </va-button>
           <va-spacer class="spacer" />
           <va-button @click="$refs.form.validate()">
-            Validate
+            Done
           </va-button>
         </div>
       </va-form>
@@ -184,7 +186,7 @@ export default defineComponent({
           .then(response => {
             this.$store.dispatch("requestHost", { token: this.$keycloak.token })
             this.$vaToast.init(({ title: response.data.state, message: `Successfully connected to ${this.selectedHost.hostname}`, color: 'success' }))
-            this.showConnectModal = !this.showConnectModal
+            this.showConnectModal = false
           })
           .catch(function (error) {
             if (error.response) {

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -56,24 +56,15 @@
         </div>
       </va-card-content>
     </va-card>
-    <va-modal style="width: 1920px;" v-model="showConnectModal" size="large" hide-default-actions>
+    <va-modal v-model="showConnectModal" size="large" hide-default-actions>
       <va-form ref="form" @validation="validation = $event, connectHost()">
-        <template #header>
-          <h2>
-            <va-icon name="link" />
-            Connecting hypervisor {{ selectedHost.hostname }}
-          </h2>
-        </template>
-        <hr>
-        <div style="width: 100%;">
-          Copy the key below into the authorized_keys file of your server
-        </div>
-        <va-alert color="secondary" class="mb-4">
-          ie. /{local_user}/.ssh/authorized_keys
-        </va-alert>
-        <va-alert icon="info" color="danger" border="top" border-color="warning" class="mb-4">
-          The local user must have access rights to KVM
-        </va-alert>
+        <h2>
+          <va-icon name="link" />
+          Connecting to the hypervisor at {{ selectedHost.hostname }}
+        </h2>
+        <hr class="mb-4">
+        <va-input label="Specify the user on the server" messages="The user must have the access rights to KVM."
+          v-model="user" type="text" :rules="[value => value?.length > 0 || 'Field is required']" class="mb-3" />
         <va-tabs v-model="currentTabKey">
           <template #tabs>
             <va-tab v-for="{ name } in sshKeys" :key="name" :name="name">
@@ -81,14 +72,13 @@
             </va-tab>
           </template>
           <div style="position: relative;">
-            <va-input class="mb-4" style="max-width:720px;" v-model="currentSshKey" type="textarea"
-              label="BackROLL SSH key" :autosize="true" :min-rows="2" readonly />
+            <va-input label="BackROLL SSH key"
+              messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
+              v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
             <va-icon name="content_copy" @click="copyToClipboard(currentSshKey)"
               style="position: absolute; top: 0; right: 0; margin-top: 4px; margin-right: 4px;" />
           </div>
         </va-tabs>
-        <va-input class="mb-4" style="max-width:720px;" label="Specify the user on the server" v-model="user"
-          type="text" :rules="[value => (value && value.length > 0) || 'Field is required']" />
         <div class="d-flex">
           <va-button flat @click="showConnectModal = !showConnectModal">
             Cancel
@@ -186,6 +176,7 @@ export default defineComponent({
         return null
       }
     },
+    // TODO Error message if connection fails.
     connectHost() {
       if (this.validation) {
         const self = this

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -77,7 +77,7 @@
             <va-input label="BackROLL SSH key"
               messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
               v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
-            <va-icon name="content_copy" @click="copyToClipboard(currentSshKey)"
+            <va-icon name="content_copy" :size="20" @click="copyToClipboard(currentSshKey)"
               style="position: absolute; top: 0; right: 0; margin-top: 4px; margin-right: 4px;" />
           </div>
         </va-tabs>

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -195,11 +195,7 @@ export default defineComponent({
             this.showConnectModal = false
           })
           .catch(function (error) {
-            if (error.response) {
-              // The request was made and the server responded with a status code
-              // that falls out of the range of 2xx
-              self.$vaToast.init(({ message: error.response.data.detail, title: 'Error', color: 'danger' }))
-            }
+            self.$vaToast.init(({ message: error?.response?.data?.detail ?? error, title: 'Error', color: 'danger' }))
           })
       }
     },

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -154,7 +154,7 @@ export default defineComponent({
   },
   watch: {
     sshKeys(newValue) {
-      this.currentTabKey = newValue[0].name
+      this.currentTabKey = newValue[0]?.name
     }
   },
   methods: {

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -78,7 +78,7 @@
               messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
               v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
             <va-icon name="content_copy" :size="20" @click="copyToClipboard(currentSshKey)"
-              style="position: absolute; top: 0; right: 0; margin-top: 4px; margin-right: 4px;" />
+              style="position: absolute; top: 0; right: 0; margin-top: 6px; margin-right: 4px;" />
           </div>
         </va-tabs>
         <div class="d-flex">

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -184,7 +184,6 @@ export default defineComponent({
         return null
       }
     },
-    // TODO Error message if connection fails.
     connectHost() {
       if (this.validation) {
         const self = this

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -77,7 +77,7 @@
             <va-input label="BackROLL SSH key"
               messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
               v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
-            <va-icon name="content_copy" :size="20" @click="copyToClipboard(currentSshKey)"
+            <va-icon :name="isKeyCopied ? 'check' : 'content_copy'" :size="20" @click="copyToClipboard(currentSshKey)"
               style="position: absolute; top: 0; right: 0; margin-top: 6px; margin-right: 4px;" />
           </div>
         </va-tabs>
@@ -131,6 +131,7 @@ export default defineComponent({
       user: null,
       sshKeys: [],
       currentTabKey: null,
+      isKeyCopied: false,
       showConnectModal: false,
       showDeleteModal: false,
       selectedHost: null
@@ -147,6 +148,9 @@ export default defineComponent({
   watch: {
     sshKeys(newValue) {
       this.currentTabKey = newValue[0]?.name
+    },
+    currentTabKey() {
+      this.isKeyCopied = false
     }
   },
   methods: {
@@ -169,6 +173,8 @@ export default defineComponent({
 
       // Supprime le textarea du document
       document.body.removeChild(textarea);
+
+      this.isKeyCopied = true;
     },
     getPool(id) {
       const result = this.$store.state.resources.poolList.find(item => item.id === id)


### PR DESCRIPTION
Multiple SSH keys has already been generated by the setup and working but they were neither managed in the API nor shown in the UI.

With this PR :
- multiple SSH keys are shown in the UI
- they are all removed from the host when the former is deleted
- the SSH keys modal is leaner
- basic error message if the connection to the hypervisor fails