### PR TITLE
Refresh bug

### DIFF
--- a/src/ui/src/App.vue
+++ b/src/ui/src/App.vue
@@ -2,32 +2,31 @@
   <router-view />
 </template>
 <script>
-
 export default {
-  name: 'app-main',
-  props: ['refreshPool'],
+  name: "app-main",
+  props: ["refreshPool"],
   mounted() {
     setInterval(() => {
       //this.$store.dispatch("requestConnector")
       //this.$store.dispatch("requestPool")
       //this.$store.dispatch("requestHost")
       //this.$store.dispatch("requestPolicy")
-      this.$store.dispatch("requestVirtualMachine")
-      this.$store.dispatch("requestJob")
-      this.$store.dispatch("requestStorage")
-      this.$store.dispatch("requestExternalHook")
-      this.$store.dispatch("requestBackupTask")
-      this.$store.dispatch("requestRestoreTask")
-    }, 10000)
-  }
-}
+      this.$store.dispatch("requestVirtualMachine");
+      this.$store.dispatch("requestJob");
+      this.$store.dispatch("requestStorage");
+      this.$store.dispatch("requestExternalHook");
+      this.$store.dispatch("requestBackupTask");
+      this.$store.dispatch("requestRestoreTask");
+    }, 10000);
+  },
+};
 </script>
 
 <style lang="scss">
-@import '~@/sass/main.scss';
+@import "~@/sass/main.scss";
 
 #app {
-  font-family: 'Source Sans Pro', Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Source Sans Pro", Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;

--- a/src/ui/src/App.vue
+++ b/src/ui/src/App.vue
@@ -7,14 +7,8 @@ export default {
   props: ["refreshPool"],
   mounted() {
     setInterval(() => {
-      //this.$store.dispatch("requestConnector")
-      //this.$store.dispatch("requestPool")
-      //this.$store.dispatch("requestHost")
-      //this.$store.dispatch("requestPolicy")
-
-      //this.$store.dispatch("requestStorage");
-      //this.$store.dispatch("requestExternalHook");
       if (this.$store.state.token) {
+        // Read-only data that can be refreshed without any conflict.
         this.$store.dispatch("requestVirtualMachine");
         this.$store.dispatch("requestJob");
         this.$store.dispatch("requestBackupTask");

--- a/src/ui/src/App.vue
+++ b/src/ui/src/App.vue
@@ -8,10 +8,10 @@ export default {
   props: ['refreshPool'],
   mounted() {
     setInterval(() => {
-      this.$store.dispatch("requestConnector")
-      this.$store.dispatch("requestPool")
-      this.$store.dispatch("requestHost")
-      this.$store.dispatch("requestPolicy")
+      //this.$store.dispatch("requestConnector")
+      //this.$store.dispatch("requestPool")
+      //this.$store.dispatch("requestHost")
+      //this.$store.dispatch("requestPolicy")
       this.$store.dispatch("requestVirtualMachine")
       this.$store.dispatch("requestJob")
       this.$store.dispatch("requestStorage")

--- a/src/ui/src/App.vue
+++ b/src/ui/src/App.vue
@@ -9,10 +9,12 @@ export default {
     setInterval(() => {
       if (this.$store.state.token) {
         // Read-only data that can be refreshed without any conflict.
-        this.$store.dispatch("requestVirtualMachine");
+
         this.$store.dispatch("requestJob");
         this.$store.dispatch("requestBackupTask");
         this.$store.dispatch("requestRestoreTask");
+
+        this.$store.dispatch("requestVirtualMachine");
       }
     }, 10000);
   },

--- a/src/ui/src/App.vue
+++ b/src/ui/src/App.vue
@@ -11,12 +11,15 @@ export default {
       //this.$store.dispatch("requestPool")
       //this.$store.dispatch("requestHost")
       //this.$store.dispatch("requestPolicy")
-      this.$store.dispatch("requestVirtualMachine");
-      this.$store.dispatch("requestJob");
-      this.$store.dispatch("requestStorage");
-      this.$store.dispatch("requestExternalHook");
-      this.$store.dispatch("requestBackupTask");
-      this.$store.dispatch("requestRestoreTask");
+
+      //this.$store.dispatch("requestStorage");
+      //this.$store.dispatch("requestExternalHook");
+      if (this.$store.state.token) {
+        this.$store.dispatch("requestVirtualMachine");
+        this.$store.dispatch("requestJob");
+        this.$store.dispatch("requestBackupTask");
+        this.$store.dispatch("requestRestoreTask");
+      }
     }, 10000);
   },
 };

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorForm.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorForm.vue
@@ -1,13 +1,10 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader
-        :title="
-          connectorId
-            ? `Updating connector ${stateConnector?.name ?? ''}`
-            : 'Adding connector'
-        "
-      />
+      <FormHeader :title="connectorId
+        ? `Updating connector ${stateConnector?.name ?? ''}`
+        : 'Adding connector'
+        " />
     </va-card-title>
     <va-card-content v-if="!connectorId || stateConnector">
       <va-alert color="info" icon="info" dense>
@@ -15,48 +12,28 @@
       </va-alert>
       <br />
       <va-form ref="form">
-        <va-input
-          label="Name"
-          v-model="formConnector.name"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        />
+        <va-input label="Name" v-model="formConnector.name"
+          :rules="[(value) => value?.length > 0 || 'Field is required']" />
         <br />
-        <va-input
-          label="Endpoint URL"
-          v-model="formConnector.url"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        />
+        <va-input label="Endpoint URL" v-model="formConnector.url"
+          :rules="[(value) => value?.length > 0 || 'Field is required']" />
         <br />
-        <va-input
-          label="Login"
-          v-model="formConnector.login"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        />
+        <va-input label="Login" v-model="formConnector.login"
+          :rules="[(value) => value?.length > 0 || 'Field is required']" />
         <br />
-        <va-input
-          v-model="formConnector.password"
-          :type="isPasswordVisible ? 'text' : 'password'"
-          label="Password"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        >
+        <va-input v-model="formConnector.password" :type="isPasswordVisible ? 'text' : 'password'" label="Password"
+          :rules="[(value) => value?.length > 0 || 'Field is required']">
           <template #appendInner>
-            <va-icon
-              :name="isPasswordVisible ? 'visibility_off' : 'visibility'"
-              size="small"
-              color="--va-primary"
-              @click="isPasswordVisible = !isPasswordVisible"
-            />
+            <va-icon :name="isPasswordVisible ? 'visibility_off' : 'visibility'" size="small" color="--va-primary"
+              @click="isPasswordVisible = !isPasswordVisible" />
           </template>
         </va-input>
       </va-form>
       <br />
-      <va-button
-        class="mb-3"
-        @click="
-          $refs.form.validate() &&
-            (connectorId ? updateConnector() : addConnector())
-        "
-      >
+      <va-button class="mb-3" @click="
+        $refs.form.validate() &&
+        (connectorId ? updateConnector() : addConnector())
+        ">
         {{ connectorId ? "Update" : "Add" }}
       </va-button>
     </va-card-content>
@@ -89,9 +66,6 @@ export default {
       isPasswordVisible: false,
     };
   },
-  mounted() {
-    this.$store.dispatch("requestConnector");
-  },
   computed: {
     stateConnector() {
       return this.$store.state.resources.connectorList.find(
@@ -103,11 +77,6 @@ export default {
     stateConnector: function () {
       this.propagateStateConnector();
     },
-  },
-  mounted() {
-    if (this.stateConnector) {
-      this.propagateStateConnector();
-    }
   },
   methods: {
     propagateStateConnector() {
@@ -149,6 +118,13 @@ export default {
           });
         });
     },
+  },
+  mounted() {
+    // TODO Wait ?
+    this.$store.dispatch("requestConnector");
+    if (this.stateConnector) {
+      this.propagateStateConnector();
+    }
   },
 };
 </script>

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorForm.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorForm.vue
@@ -1,7 +1,13 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader :title="connectorId ? `Updating connector ${stateConnector?.name ?? ''}` : 'Adding connector'" />
+      <FormHeader
+        :title="
+          connectorId
+            ? `Updating connector ${stateConnector?.name ?? ''}`
+            : 'Adding connector'
+        "
+      />
     </va-card-title>
     <va-card-content v-if="!connectorId || stateConnector">
       <va-alert color="info" icon="info" dense>
@@ -9,25 +15,48 @@
       </va-alert>
       <br />
       <va-form ref="form">
-        <va-input label="Name" v-model="formConnector.name"
-          :rules="[(value) => value?.length > 0 || 'Field is required']" />
+        <va-input
+          label="Name"
+          v-model="formConnector.name"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        />
         <br />
-        <va-input label="Endpoint URL" v-model="formConnector.url"
-          :rules="[(value) => value?.length > 0 || 'Field is required']" />
+        <va-input
+          label="Endpoint URL"
+          v-model="formConnector.url"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        />
         <br />
-        <va-input label="Login" v-model="formConnector.login"
-          :rules="[(value) => value?.length > 0 || 'Field is required']" />
+        <va-input
+          label="Login"
+          v-model="formConnector.login"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        />
         <br />
-        <va-input v-model="formConnector.password" :type="isPasswordVisible ? 'text' : 'password'" label="Password"
-          :rules="[(value) => value?.length > 0 || 'Field is required']">
+        <va-input
+          v-model="formConnector.password"
+          :type="isPasswordVisible ? 'text' : 'password'"
+          label="Password"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        >
           <template #appendInner>
-            <va-icon :name="isPasswordVisible ? 'visibility_off' : 'visibility'" size="small" color="--va-primary"
-              @click="isPasswordVisible = !isPasswordVisible" />
+            <va-icon
+              :name="isPasswordVisible ? 'visibility_off' : 'visibility'"
+              size="small"
+              color="--va-primary"
+              @click="isPasswordVisible = !isPasswordVisible"
+            />
           </template>
         </va-input>
       </va-form>
       <br />
-      <va-button class="mb-3" @click="$refs.form.validate() && (connectorId ? updateConnector() : addConnector())">
+      <va-button
+        class="mb-3"
+        @click="
+          $refs.form.validate() &&
+            (connectorId ? updateConnector() : addConnector())
+        "
+      >
         {{ connectorId ? "Update" : "Add" }}
       </va-button>
     </va-card-content>
@@ -46,7 +75,7 @@ import FormHeader from "@/components/forms/FormHeader.vue";
 export default {
   components: {
     ...spinners,
-    FormHeader
+    FormHeader,
   },
   data() {
     return {
@@ -59,6 +88,9 @@ export default {
       },
       isPasswordVisible: false,
     };
+  },
+  mounted() {
+    this.$store.dispatch("requestConnector");
   },
   computed: {
     stateConnector() {
@@ -111,8 +143,8 @@ export default {
             color: "success",
           });
         })
-        .catch(error => {
-          console.error(error)
+        .catch((error) => {
+          console.error(error);
           this.$vaToast.init({
             title: "Unable to add connector",
             message: error?.response?.data?.detail ?? error,

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
@@ -64,6 +64,9 @@ export default defineComponent({
       selectedConnector: null
     }
   },
+  mounted() {
+    this.$store.dispatch("requestConnector", { token: this.$store.state.token });
+  },
   computed: {
   },
   methods: {

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
@@ -89,6 +89,25 @@ export default defineComponent({
   },
   computed: {},
   methods: {
+    // async onSubmit() {
+    //   const result = await this.$store.dispatch("updateConnector", {
+    //     connectorValues: this.connectorValues,
+    //   });
+
+    //   if (result.success) {
+    //     this.$router.push("/admin/configuration/connectors");
+    //     this.$vaToast.init({
+    //       message: "Connector has been successfully updated",
+    //       color: "success",
+    //     });
+    //   } else {
+    //     this.$vaToast.init({
+    //       title: "Error!",
+    //       message: result.message,
+    //       color: "danger",
+    //     });
+    //   }
+    // },
     deleteConnector() {
       const connector = { ...this.selectedConnector };
       axios

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
@@ -66,32 +66,7 @@ export default defineComponent({
       selectedConnector: null,
     };
   },
-  mounted() {
-    this.$store.dispatch("requestConnector", {
-      token: this.$store.state.token,
-    });
-  },
-  computed: {},
   methods: {
-    // async onSubmit() {
-    //   const result = await this.$store.dispatch("updateConnector", {
-    //     connectorValues: this.connectorValues,
-    //   });
-
-    //   if (result.success) {
-    //     this.$router.push("/admin/configuration/connectors");
-    //     this.$vaToast.init({
-    //       message: "Connector has been successfully updated",
-    //       color: "success",
-    //     });
-    //   } else {
-    //     this.$vaToast.init({
-    //       title: "Error!",
-    //       message: result.message,
-    //       color: "danger",
-    //     });
-    //   }
-    // },
     deleteConnector() {
       const connector = { ...this.selectedConnector };
       axios
@@ -121,6 +96,9 @@ export default defineComponent({
           });
         });
     },
+  },
+  mounted() {
+    this.$store.dispatch("requestConnector");
   },
 });
 </script>

--- a/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
+++ b/src/ui/src/pages/admin/configuration/connectors/ConnectorList.vue
@@ -1,11 +1,17 @@
 <template>
   <va-card>
     <va-card-title>
-      <ListHeader title="Connectors" plus-button-title="Add connector"
-        plus-button-route="/admin/configuration/connectors/new" />
+      <ListHeader
+        title="Connectors"
+        plus-button-title="Add connector"
+        plus-button-route="/admin/configuration/connectors/new"
+      />
     </va-card-title>
     <va-card-content>
-      <va-data-table :items="$store.state.resources.connectorList" :columns="columns">
+      <va-data-table
+        :items="$store.state.resources.connectorList"
+        :columns="columns"
+      >
         <template #cell(name)="{ value }">
           {{ value }}
         </template>
@@ -14,14 +20,29 @@
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button icon="settings"
-              @click="this.$router.push(`/admin/configuration/connectors/${$store.state.resources.connectorList[rowIndex].id}`)" />
-            <va-button icon="delete"
-              @click="selectedConnector = $store.state.resources.connectorList[rowIndex], showDeleteModal = !showDeleteModal" />
+            <va-button
+              icon="settings"
+              @click="
+                this.$router.push(
+                  `/admin/configuration/connectors/${$store.state.resources.connectorList[rowIndex].id}`
+                )
+              "
+            />
+            <va-button
+              icon="delete"
+              @click="
+                (selectedConnector =
+                  $store.state.resources.connectorList[rowIndex]),
+                  (showDeleteModal = !showDeleteModal)
+              "
+            />
           </va-button-group>
         </template>
       </va-data-table>
-      <div v-if="!$store.state.isexternalHookTableReady" class="flex-center ma-3">
+      <div
+        v-if="!$store.state.isexternalHookTableReady"
+        class="flex-center ma-3"
+      >
         <spring-spinner :animation-duration="2000" :size="30" color="#2c82e0" />
       </div>
     </va-card-content>
@@ -33,61 +54,74 @@
         Removing connector
       </h2>
     </template>
-    <hr>
+    <hr />
     <div>
-      You are about to remove connector <b>{{ JSON.parse(JSON.stringify(this.selectedConnector)).name }}</b>.
-      <br>Please confirm action.
+      You are about to remove connector
+      <b>{{ JSON.parse(JSON.stringify(this.selectedConnector)).name }}</b
+      >. <br />Please confirm action.
     </div>
   </va-modal>
 </template>
 <script>
-import axios from 'axios'
-import { defineComponent } from 'vue'
-import * as spinners from 'epic-spinners'
+import axios from "axios";
+import { defineComponent } from "vue";
+import * as spinners from "epic-spinners";
 
-import ListHeader from '@/components/lists/ListHeader.vue'
+import ListHeader from "@/components/lists/ListHeader.vue";
 
 export default defineComponent({
-  name: 'PoliciesTable',
+  name: "PoliciesTable",
   components: {
     ...spinners,
-    ListHeader
+    ListHeader,
   },
   data() {
     return {
-      columns: [
-        { key: 'name' },
-        { key: 'url' },
-        { key: 'actions' }
-      ],
+      columns: [{ key: "name" }, { key: "url" }, { key: "actions" }],
       showDeleteModal: false,
-      selectedConnector: null
-    }
+      selectedConnector: null,
+    };
   },
   mounted() {
-    this.$store.dispatch("requestConnector", { token: this.$store.state.token });
+    this.$store.dispatch("requestConnector", {
+      token: this.$store.state.token,
+    });
   },
-  computed: {
-  },
+  computed: {},
   methods: {
     deleteConnector() {
-      const connector = { ...this.selectedConnector }
-      axios.delete(`${this.$store.state.endpoint.api}/api/v1/connectors/${connector.id}`, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-        .then(response => {
-          this.$store.dispatch("requestConnector", { token: this.$store.state.token })
-          this.$vaToast.init({ title: response.data.state, message: 'connector has been successfully removed', color: 'success' })
-        })
-        .catch(error => {
-          console.error(error)
+      const connector = { ...this.selectedConnector };
+      axios
+        .delete(
+          `${this.$store.state.endpoint.api}/api/v1/connectors/${connector.id}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${this.$store.state.token}`,
+            },
+          }
+        )
+        .then((response) => {
+          this.$store.dispatch("requestConnector", {
+            token: this.$store.state.token,
+          });
           this.$vaToast.init({
-            title: 'Unable to remove connector',
-            message: error?.message ?? error,
-            color: 'danger'
-          })
+            title: response.data.state,
+            message: "connector has been successfully removed",
+            color: "success",
+          });
         })
-    }
-  }
-})
+        .catch((error) => {
+          console.error(error);
+          this.$vaToast.init({
+            title: "Unable to remove connector",
+            message: error?.message ?? error,
+            color: "danger",
+          });
+        });
+    },
+  },
+});
 </script>
 <style scoped>
 .text-right {

--- a/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookForm.vue
+++ b/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookForm.vue
@@ -1,7 +1,13 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader :title="hookId ? `Updating hook ${stateHook?.name ?? ''}` : 'Adding external hook'" />
+      <FormHeader
+        :title="
+          hookId
+            ? `Updating hook ${stateHook?.name ?? ''}`
+            : 'Adding external hook'
+        "
+      />
     </va-card-title>
     <va-card-content v-if="!hookId || stateHook">
       <va-alert color="info" icon="info" dense>
@@ -9,21 +15,40 @@
       </va-alert>
       <br />
       <va-form ref="form">
-        <va-input label="Name" v-model="formHook.name" :rules="[(value) => value?.length > 0 || 'Field is required']" />
+        <va-input
+          label="Name"
+          v-model="formHook.name"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        />
         <br />
-        <va-input label="Provider" v-model="formHook.provider"
-          :rules="[(value) => value?.length > 0 || 'Field is required']" readonly />
+        <va-input
+          label="Provider"
+          v-model="formHook.provider"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+          readonly
+        />
         <br />
-        <va-input v-model="formHook.value" :type="isPasswordVisible ? 'text' : 'password'" label="Value"
-          :rules="[(value) => value?.length > 0 || 'Field is required']">
+        <va-input
+          v-model="formHook.value"
+          :type="isPasswordVisible ? 'text' : 'password'"
+          label="Value"
+          :rules="[(value) => value?.length > 0 || 'Field is required']"
+        >
           <template #appendInner>
-            <va-icon :name="isPasswordVisible ? 'visibility_off' : 'visibility'" size="small" color="--va-primary"
-              @click="isPasswordVisible = !isPasswordVisible" />
+            <va-icon
+              :name="isPasswordVisible ? 'visibility_off' : 'visibility'"
+              size="small"
+              color="--va-primary"
+              @click="isPasswordVisible = !isPasswordVisible"
+            />
           </template>
         </va-input>
       </va-form>
       <br />
-      <va-button class="mb-3" @click="$refs.form.validate() && (hookId ? updateHook() : addHook())">
+      <va-button
+        class="mb-3"
+        @click="$refs.form.validate() && (hookId ? updateHook() : addHook())"
+      >
         {{ hookId ? "Update" : "Add" }}
       </va-button>
     </va-card-content>
@@ -42,7 +67,7 @@ import FormHeader from "@/components/forms/FormHeader.vue";
 export default {
   components: {
     ...spinners,
-    FormHeader
+    FormHeader,
   },
   data() {
     return {
@@ -54,6 +79,9 @@ export default {
       },
       isPasswordVisible: false,
     };
+  },
+  mounted() {
+    this.$store.dispatch("requestExternalHook");
   },
   computed: {
     stateHook() {
@@ -108,8 +136,8 @@ export default {
             color: "success",
           });
         })
-        .catch(error => {
-          console.error(error)
+        .catch((error) => {
+          console.error(error);
           this.$vaToast.init({
             title: "Unable to add external hook",
             message: error?.response?.data?.detail ?? error,

--- a/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookForm.vue
+++ b/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookForm.vue
@@ -1,13 +1,10 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader
-        :title="
-          hookId
-            ? `Updating hook ${stateHook?.name ?? ''}`
-            : 'Adding external hook'
-        "
-      />
+      <FormHeader :title="hookId
+        ? `Updating hook ${stateHook?.name ?? ''}`
+        : 'Adding external hook'
+        " />
     </va-card-title>
     <va-card-content v-if="!hookId || stateHook">
       <va-alert color="info" icon="info" dense>
@@ -15,40 +12,21 @@
       </va-alert>
       <br />
       <va-form ref="form">
-        <va-input
-          label="Name"
-          v-model="formHook.name"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        />
+        <va-input label="Name" v-model="formHook.name" :rules="[(value) => value?.length > 0 || 'Field is required']" />
         <br />
-        <va-input
-          label="Provider"
-          v-model="formHook.provider"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-          readonly
-        />
+        <va-input label="Provider" v-model="formHook.provider"
+          :rules="[(value) => value?.length > 0 || 'Field is required']" readonly />
         <br />
-        <va-input
-          v-model="formHook.value"
-          :type="isPasswordVisible ? 'text' : 'password'"
-          label="Value"
-          :rules="[(value) => value?.length > 0 || 'Field is required']"
-        >
+        <va-input v-model="formHook.value" :type="isPasswordVisible ? 'text' : 'password'" label="Value"
+          :rules="[(value) => value?.length > 0 || 'Field is required']">
           <template #appendInner>
-            <va-icon
-              :name="isPasswordVisible ? 'visibility_off' : 'visibility'"
-              size="small"
-              color="--va-primary"
-              @click="isPasswordVisible = !isPasswordVisible"
-            />
+            <va-icon :name="isPasswordVisible ? 'visibility_off' : 'visibility'" size="small" color="--va-primary"
+              @click="isPasswordVisible = !isPasswordVisible" />
           </template>
         </va-input>
       </va-form>
       <br />
-      <va-button
-        class="mb-3"
-        @click="$refs.form.validate() && (hookId ? updateHook() : addHook())"
-      >
+      <va-button class="mb-3" @click="$refs.form.validate() && (hookId ? updateHook() : addHook())">
         {{ hookId ? "Update" : "Add" }}
       </va-button>
     </va-card-content>
@@ -80,9 +58,6 @@ export default {
       isPasswordVisible: false,
     };
   },
-  mounted() {
-    this.$store.dispatch("requestExternalHook");
-  },
   computed: {
     stateHook() {
       return this.$store.state.resources.externalHookList.find(
@@ -94,11 +69,6 @@ export default {
     stateHook: function () {
       this.propagateStateHook();
     },
-  },
-  mounted() {
-    if (this.stateHook) {
-      this.propagateStateHook();
-    }
   },
   methods: {
     propagateStateHook() {
@@ -142,6 +112,13 @@ export default {
           });
         });
     },
+  },
+  mounted() {
+    // TODO Wait ?
+    this.$store.dispatch("requestExternalHook");
+    if (this.stateHook) {
+      this.propagateStateHook();
+    }
   },
 };
 </script>

--- a/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookList.vue
+++ b/src/ui/src/pages/admin/configuration/externalhooks/ExternalHookList.vue
@@ -97,7 +97,10 @@ export default defineComponent({
           })
         })
     }
-  }
+  },
+  mounted() {
+    this.$store.dispatch("requestExternalHook");
+  },
 })
 </script>
 <style scoped>

--- a/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
+++ b/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
@@ -2,100 +2,61 @@
   <div>
     <va-card>
       <va-card-title>
-        <ListHeader
-          title="policies"
-          plus-button-title="Create policy"
-          plus-button-route="/admin/configuration/policies/new"
-          :dependencies-resolved="areDependenciesResolved"
-          dependencies-message="You need to add a storage."
-          go-button-title="Go to storage"
-          go-button-route="/admin/configuration/storage"
-        />
+        <ListHeader title="policies" plus-button-title="Create policy"
+          plus-button-route="/admin/configuration/policies/new" :dependencies-resolved="areDependenciesResolved"
+          dependencies-message="You need to add a storage." go-button-title="Go to storage"
+          go-button-route="/admin/configuration/storage" />
       </va-card-title>
       <va-card-content>
-        <va-data-table
-          :items="$store.state.resources.policyList"
-          :columns="columns"
-        >
+        <va-data-table :items="$store.state.resources.policyList" :columns="columns">
           <template #cell(schedule)="{ value }">
             <va-chip size="small" outline square>
               {{ humanCron(value) }}
             </va-chip>
           </template>
           <template #cell(externalhook)="{ value }">
-            <va-chip
-              @click="this.$router.push('/admin/configuration/externalhooks')"
-              size="small"
-              outline
-              square
-            >
+            <va-chip @click="this.$router.push('/admin/configuration/externalhooks')" size="small" outline square>
               {{ value }}
             </va-chip>
           </template>
-          <template #cell(enabled)="{ value }"
-            ><va-chip
-              size="small"
-              :color="JSON.parse(value) ? 'success' : 'danger'"
-            >
+          <template #cell(enabled)="{ value }"><va-chip size="small" :color="JSON.parse(value) ? 'success' : 'danger'">
               {{ JSON.parse(value) ? "Enabled" : "Disabled" }}
             </va-chip>
           </template>
           <template #cell(storage)="{ value }">
-            <va-chip
-              size="small"
-              square
-              @click="this.$router.push('/admin/configuration/storage')"
-            >
+            <va-chip size="small" square @click="this.$router.push('/admin/configuration/storage')">
               {{ getStorage(value) }}
             </va-chip>
           </template>
           <template #cell(actions)="{ rowIndex }">
             <va-button-group gradient :rounded="false">
-              <va-button
-                v-if="
-                  JSON.parse(
-                    $store.state.resources.policyList[rowIndex].enabled
-                  )
-                "
-                icon="block"
-                @click="
-                  (selectedPolicy =
-                    $store.state.resources.policyList[rowIndex]),
-                    (showDisableModal = !showDisableModal)
-                "
-              />
-              <va-button
-                v-else
-                icon="start"
-                @click="
-                  enablePolicy($store.state.resources.policyList[rowIndex])
-                "
-              />
-              <va-button
-                icon="settings"
-                @click="
-                  this.$router.push(
-                    `/admin/configuration/policy/${$store.state.resources.policyList[rowIndex].id}`
-                  )
-                "
-              />
-              <va-button
-                icon="delete"
-                @click="
-                  (selectedPolicy =
-                    $store.state.resources.policyList[rowIndex]),
-                    (showDeleteModal = !showDeleteModal)
-                "
-              />
+              <va-button v-if="
+                JSON.parse(
+                  $store.state.resources.policyList[rowIndex].enabled
+                )
+              " icon="block" @click="
+                (selectedPolicy =
+                  $store.state.resources.policyList[rowIndex]),
+                  (showDisableModal = !showDisableModal)
+                  " />
+              <va-button v-else icon="start" @click="
+                enablePolicy($store.state.resources.policyList[rowIndex])
+                " />
+              <va-button icon="settings" @click="
+                this.$router.push(
+                  `/admin/configuration/policy/${$store.state.resources.policyList[rowIndex].id}`
+                )
+                " />
+              <va-button icon="delete" @click="
+              (selectedPolicy =
+                $store.state.resources.policyList[rowIndex]),
+                (showDeleteModal = !showDeleteModal)
+                " />
             </va-button-group>
           </template>
         </va-data-table>
         <div v-if="!$store.state.isPolicyTableReady" class="flex-center ma-3">
-          <spring-spinner
-            :animation-duration="2000"
-            :size="30"
-            color="#2c82e0"
-          />
+          <spring-spinner :animation-duration="2000" :size="30" color="#2c82e0" />
         </div>
       </va-card-content>
     </va-card>
@@ -109,8 +70,7 @@
       <hr />
       <div>
         You are about to disable policy
-        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b
-        >. <br />Please confirm action.
+        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b>. <br />Please confirm action.
       </div>
     </va-modal>
     <va-modal v-model="showDeleteModal" @ok="deletePolicy()">
@@ -123,8 +83,7 @@
       <hr />
       <div>
         You are about to remove policy
-        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b
-        >. <br />Please confirm action.
+        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b>. <br />Please confirm action.
       </div>
     </va-modal>
   </div>
@@ -159,7 +118,7 @@ export default defineComponent({
     };
   },
   mounted() {
-    this.$store.dispatch("requestPolicy", { token: this.$store.state.token });
+    this.$store.dispatch("requestPolicy");
   },
   computed: {
     areDependenciesResolved() {

--- a/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
+++ b/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
@@ -2,46 +2,100 @@
   <div>
     <va-card>
       <va-card-title>
-        <ListHeader title="policies" plus-button-title="Create policy"
-          plus-button-route="/admin/configuration/policies/new" :dependencies-resolved="areDependenciesResolved"
-          dependencies-message="You need to add a storage." go-button-title="Go to storage"
-          go-button-route="/admin/configuration/storage" />
+        <ListHeader
+          title="policies"
+          plus-button-title="Create policy"
+          plus-button-route="/admin/configuration/policies/new"
+          :dependencies-resolved="areDependenciesResolved"
+          dependencies-message="You need to add a storage."
+          go-button-title="Go to storage"
+          go-button-route="/admin/configuration/storage"
+        />
       </va-card-title>
       <va-card-content>
-        <va-data-table :items="$store.state.resources.policyList" :columns="columns">
+        <va-data-table
+          :items="$store.state.resources.policyList"
+          :columns="columns"
+        >
           <template #cell(schedule)="{ value }">
             <va-chip size="small" outline square>
               {{ humanCron(value) }}
             </va-chip>
           </template>
           <template #cell(externalhook)="{ value }">
-            <va-chip @click="this.$router.push('/admin/configuration/externalhooks')" size="small" outline square>
+            <va-chip
+              @click="this.$router.push('/admin/configuration/externalhooks')"
+              size="small"
+              outline
+              square
+            >
               {{ value }}
             </va-chip>
           </template>
-          <template #cell(enabled)="{ value }"><va-chip size="small" :color="JSON.parse(value) ? 'success' : 'danger'">
-              {{ JSON.parse(value) ? 'Enabled' : 'Disabled' }}
+          <template #cell(enabled)="{ value }"
+            ><va-chip
+              size="small"
+              :color="JSON.parse(value) ? 'success' : 'danger'"
+            >
+              {{ JSON.parse(value) ? "Enabled" : "Disabled" }}
             </va-chip>
           </template>
           <template #cell(storage)="{ value }">
-            <va-chip size="small" square @click="this.$router.push('/admin/configuration/storage')">
+            <va-chip
+              size="small"
+              square
+              @click="this.$router.push('/admin/configuration/storage')"
+            >
               {{ getStorage(value) }}
             </va-chip>
           </template>
           <template #cell(actions)="{ rowIndex }">
             <va-button-group gradient :rounded="false">
-              <va-button v-if="JSON.parse($store.state.resources.policyList[rowIndex].enabled)" icon="block"
-                @click="selectedPolicy = $store.state.resources.policyList[rowIndex], showDisableModal = !showDisableModal" />
-              <va-button v-else icon="start" @click="enablePolicy($store.state.resources.policyList[rowIndex])" />
-              <va-button icon="settings"
-                @click="this.$router.push(`/admin/configuration/policy/${$store.state.resources.policyList[rowIndex].id}`)" />
-              <va-button icon="delete"
-                @click="selectedPolicy = $store.state.resources.policyList[rowIndex], showDeleteModal = !showDeleteModal" />
+              <va-button
+                v-if="
+                  JSON.parse(
+                    $store.state.resources.policyList[rowIndex].enabled
+                  )
+                "
+                icon="block"
+                @click="
+                  (selectedPolicy =
+                    $store.state.resources.policyList[rowIndex]),
+                    (showDisableModal = !showDisableModal)
+                "
+              />
+              <va-button
+                v-else
+                icon="start"
+                @click="
+                  enablePolicy($store.state.resources.policyList[rowIndex])
+                "
+              />
+              <va-button
+                icon="settings"
+                @click="
+                  this.$router.push(
+                    `/admin/configuration/policy/${$store.state.resources.policyList[rowIndex].id}`
+                  )
+                "
+              />
+              <va-button
+                icon="delete"
+                @click="
+                  (selectedPolicy =
+                    $store.state.resources.policyList[rowIndex]),
+                    (showDeleteModal = !showDeleteModal)
+                "
+              />
             </va-button-group>
           </template>
         </va-data-table>
         <div v-if="!$store.state.isPolicyTableReady" class="flex-center ma-3">
-          <spring-spinner :animation-duration="2000" :size="30" color="#2c82e0" />
+          <spring-spinner
+            :animation-duration="2000"
+            :size="30"
+            color="#2c82e0"
+          />
         </div>
       </va-card-content>
     </va-card>
@@ -52,10 +106,11 @@
           Disabling Backup Policy
         </h2>
       </template>
-      <hr>
+      <hr />
       <div>
-        You are about to disable policy <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b>.
-        <br>Please confirm action.
+        You are about to disable policy
+        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b
+        >. <br />Please confirm action.
       </div>
     </va-modal>
     <va-modal v-model="showDeleteModal" @ok="deletePolicy()">
@@ -65,25 +120,26 @@
           Removing Backup Policy
         </h2>
       </template>
-      <hr>
+      <hr />
       <div>
-        You are about to remove policy <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b>.
-        <br>Please confirm action.
+        You are about to remove policy
+        <b>{{ JSON.parse(JSON.stringify(this.selectedPolicy)).name }}</b
+        >. <br />Please confirm action.
       </div>
     </va-modal>
   </div>
 </template>
 
 <script>
-import axios from 'axios'
-import { defineComponent } from 'vue'
-import cronstrue from 'cronstrue'
-import * as spinners from 'epic-spinners'
+import axios from "axios";
+import { defineComponent } from "vue";
+import cronstrue from "cronstrue";
+import * as spinners from "epic-spinners";
 
-import ListHeader from "@/components/lists/ListHeader.vue"
+import ListHeader from "@/components/lists/ListHeader.vue";
 
 export default defineComponent({
-  name: 'PoliciesTable',
+  name: "PoliciesTable",
   components: {
     ...spinners,
     ListHeader,
@@ -91,16 +147,16 @@ export default defineComponent({
   data() {
     return {
       columns: [
-        { key: 'name' },
-        { key: 'schedule' },
-        { key: 'storage' },
-        { key: 'enabled', label: "auto-start" },
-        { key: 'actions' }
+        { key: "name" },
+        { key: "schedule" },
+        { key: "storage" },
+        { key: "enabled", label: "auto-start" },
+        { key: "actions" },
       ],
       showDeleteModal: false,
       showDisableModal: false,
-      selectedPolicy: null
-    }
+      selectedPolicy: null,
+    };
   },
   mounted() {
     this.$store.dispatch("requestPolicy", { token: this.$store.state.token });
@@ -108,64 +164,82 @@ export default defineComponent({
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.
-      return !this.$store.state.isStorageTableReady || this.$store.state.storageList.length > 0;
-    }
+      return (
+        !this.$store.state.isStorageTableReady ||
+        this.$store.state.storageList.length > 0
+      );
+    },
   },
   methods: {
     humanCron(value) {
       // Let the other rows render by catching the error.
       try {
-        return cronstrue.toString(value)
+        return cronstrue.toString(value);
       } catch {
-        return "Invalid – Please update the schedule."
+        return "Invalid – Please update the schedule.";
       }
     },
     getStorage(id) {
       if (this.$store.state.isStorageTableReady) {
         const result = this.$store.state.storageList.filter((item) => {
-          return item.id == id
-        })
-        return result[0].name.toUpperCase()
+          return item.id == id;
+        });
+        return result[0].name.toUpperCase();
       } else {
-        return "loading..."
+        return "loading...";
       }
     },
     deletePolicy() {
-      const policy = { ...this.selectedPolicy }
-      axios.delete(`${this.$store.state.endpoint.api}/api/v1/backup_policies/${policy.id}`, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-        .then(response => {
-          this.$store.dispatch("requestPolicy", { token: this.$store.state.token })
-          this.$vaToast.init({ title: response.data.state, message: 'Policy has been successfully removed', color: 'success' })
-        })
-        .catch(error => {
-          console.error(error)
+      const policy = { ...this.selectedPolicy };
+      axios
+        .delete(
+          `${this.$store.state.endpoint.api}/api/v1/backup_policies/${policy.id}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${this.$store.state.token}`,
+            },
+          }
+        )
+        .then((response) => {
+          this.$store.dispatch("requestPolicy", {
+            token: this.$store.state.token,
+          });
           this.$vaToast.init({
-            title: 'Unable to remove policy',
-            message: error?.response?.data?.detail ?? error,
-            color: 'danger'
-          })
+            title: response.data.state,
+            message: "Policy has been successfully removed",
+            color: "success",
+          });
         })
+        .catch((error) => {
+          console.error(error);
+          this.$vaToast.init({
+            title: "Unable to remove policy",
+            message: error?.response?.data?.detail ?? error,
+            color: "danger",
+          });
+        });
     },
     disablePolicy() {
-      const policy = { ...this.selectedPolicy }
-      policy.state = 0
+      const policy = { ...this.selectedPolicy };
+      policy.state = 0;
       this.$store.dispatch("updatePolicy", {
         vm: this,
         token: this.$store.state.token,
         policyValues: policy,
-      })
+      });
     },
     enablePolicy(object) {
-      const policy = { ...object }
-      policy.state = 1
+      const policy = { ...object };
+      policy.state = 1;
       this.$store.dispatch("updatePolicy", {
         vm: this,
         token: this.$store.state.token,
         policyValues: policy,
-      })
-    }
-  }
-})
+      });
+    },
+  },
+});
 </script>
 <style scoped>
 .text-right {

--- a/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
+++ b/src/ui/src/pages/admin/configuration/policies/PolicyList.vue
@@ -102,6 +102,9 @@ export default defineComponent({
       selectedPolicy: null
     }
   },
+  mounted() {
+    this.$store.dispatch("requestPolicy", { token: this.$store.state.token });
+  },
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.

--- a/src/ui/src/pages/admin/configuration/policies/dayOfWeek.js
+++ b/src/ui/src/pages/admin/configuration/policies/dayOfWeek.js
@@ -4,7 +4,7 @@ const mapping = [
   "Monday",
   "Tuesday",
   "Wednesday",
-  "Thrusday",
+  "Thursday",
   "Friday",
   "Saturday",
   "Sunday",

--- a/src/ui/src/pages/admin/configuration/storage/StorageForm.vue
+++ b/src/ui/src/pages/admin/configuration/storage/StorageForm.vue
@@ -1,13 +1,10 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader
-        :title="
-          storageId
-            ? `Updating storage ${stateStorage?.name ?? ''}`
-            : 'Adding storage'
-        "
-      />
+      <FormHeader :title="storageId
+        ? `Updating storage ${stateStorage?.name ?? ''}`
+        : 'Adding storage'
+        " />
     </va-card-title>
     <va-card-content v-if="!storageId || stateStorage">
       <va-alert border="top" class="mb-4">
@@ -18,33 +15,22 @@
         containers.<br />
         To do this, update the following portion in the docker-compose:
         <code class="consoleStyle">
-          volumes:<br />
-          - /mnt:/mnt
-        </code>
+  volumes:<br />
+  - /mnt:/mnt
+</code>
         This example gives access to the /mnt directory where NFS shares
         dedicated to backup storage can be mounted.
       </va-alert>
       <va-form ref="form">
-        <va-input
-          label="Name"
-          v-model="formStorage.name"
-          :rules="storageNameRules"
-        />
+        <va-input label="Name" v-model="formStorage.name" :rules="storageNameRules" />
         <br />
-        <va-input
-          label="Path"
-          placeholder="eg. /mnt/myNFSbackend"
-          v-model="formStorage.path"
-          :rules="storagePathRules"
-        />
+        <va-input label="Path" placeholder="eg. /mnt/myNFSbackend" v-model="formStorage.path"
+          :rules="storagePathRules" />
         <br />
-        <va-button
-          class="mb-3"
-          @click="
-            $refs.form.validate() &&
-              (storageId ? updateStorage() : addStorage())
-          "
-        >
+        <va-button class="mb-3" @click="
+          $refs.form.validate() &&
+          (storageId ? updateStorage() : addStorage())
+          ">
           {{ storageId ? "Update" : "Add" }}
         </va-button>
       </va-form>
@@ -102,9 +88,6 @@ export default {
       ],
     };
   },
-  mounted() {
-    this.$store.dispatch("requestStorage");
-  },
   computed: {
     otherStorageList() {
       return this.$store.state.storageList.filter(
@@ -129,11 +112,6 @@ export default {
     stateStorage: function () {
       this.propagateStateStorage();
     },
-  },
-  mounted() {
-    if (this.stateStorage) {
-      this.propagateStateStorage();
-    }
   },
   methods: {
     propagateStateStorage() {
@@ -179,6 +157,13 @@ export default {
           });
         });
     },
+  },
+  mounted() {
+    // TODO Wait for the refreshed data ?
+    this.$store.dispatch("requestStorage");
+    if (this.stateStorage) {
+      this.propagateStateStorage();
+    }
   },
 };
 </script>

--- a/src/ui/src/pages/admin/configuration/storage/StorageForm.vue
+++ b/src/ui/src/pages/admin/configuration/storage/StorageForm.vue
@@ -1,7 +1,13 @@
 <template>
   <va-card>
     <va-card-title>
-      <FormHeader :title="storageId ? `Updating storage ${stateStorage?.name ?? ''}` : 'Adding storage'" />
+      <FormHeader
+        :title="
+          storageId
+            ? `Updating storage ${stateStorage?.name ?? ''}`
+            : 'Adding storage'
+        "
+      />
     </va-card-title>
     <va-card-content v-if="!storageId || stateStorage">
       <va-alert border="top" class="mb-4">
@@ -12,19 +18,33 @@
         containers.<br />
         To do this, update the following portion in the docker-compose:
         <code class="consoleStyle">
-  volumes:<br />
-  - /mnt:/mnt
-</code>
+          volumes:<br />
+          - /mnt:/mnt
+        </code>
         This example gives access to the /mnt directory where NFS shares
         dedicated to backup storage can be mounted.
       </va-alert>
       <va-form ref="form">
-        <va-input label="Name" v-model="formStorage.name" :rules="storageNameRules" />
+        <va-input
+          label="Name"
+          v-model="formStorage.name"
+          :rules="storageNameRules"
+        />
         <br />
-        <va-input label="Path" placeholder="eg. /mnt/myNFSbackend" v-model="formStorage.path"
-          :rules="storagePathRules" />
+        <va-input
+          label="Path"
+          placeholder="eg. /mnt/myNFSbackend"
+          v-model="formStorage.path"
+          :rules="storagePathRules"
+        />
         <br />
-        <va-button class="mb-3" @click="$refs.form.validate() && (storageId ? updateStorage() : addStorage())">
+        <va-button
+          class="mb-3"
+          @click="
+            $refs.form.validate() &&
+              (storageId ? updateStorage() : addStorage())
+          "
+        >
           {{ storageId ? "Update" : "Add" }}
         </va-button>
       </va-form>
@@ -49,7 +69,7 @@ export default {
   name: "updateStorage",
   components: {
     ...spinners,
-    FormHeader
+    FormHeader,
   },
   data() {
     return {
@@ -81,6 +101,9 @@ export default {
         },
       ],
     };
+  },
+  mounted() {
+    this.$store.dispatch("requestStorage");
   },
   computed: {
     otherStorageList() {
@@ -150,8 +173,8 @@ export default {
             color: "success",
           });
         })
-        .catch(error => {
-          console.error(error)
+        .catch((error) => {
+          console.error(error);
           this.$vaToast.init({
             title: "Unable to add storage",
             message: error?.response?.data?.detail ?? error,

--- a/src/ui/src/pages/admin/configuration/storage/StorageList.vue
+++ b/src/ui/src/pages/admin/configuration/storage/StorageList.vue
@@ -118,7 +118,10 @@ export default defineComponent({
       } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
       return bytes.toFixed(dp) + ' ' + units[u];
     }
-  }
+  },
+  mounted() {
+    this.$store.dispatch("requestStorage");
+  },
 })
 </script>
 <style scoped>

--- a/src/ui/src/pages/admin/dashboard/DashboardCharts.vue
+++ b/src/ui/src/pages/admin/dashboard/DashboardCharts.vue
@@ -72,6 +72,9 @@ export default defineComponent({
   mounted() {
     this.lineChartData = getLineChartData(this.theme)
     this.donutChartData = getDonutChartData(this.theme, this.poolListName, this.vmListCountperPool)
+
+    // TODO Add all dependecies.
+    this.$store.dispatch("requestBackupTask");
   },
   watch: {
     '$themes.success'() {

--- a/src/ui/src/pages/admin/dashboard/DashboardCharts.vue
+++ b/src/ui/src/pages/admin/dashboard/DashboardCharts.vue
@@ -73,8 +73,11 @@ export default defineComponent({
     this.lineChartData = getLineChartData(this.theme)
     this.donutChartData = getDonutChartData(this.theme, this.poolListName, this.vmListCountperPool)
 
-    // TODO Add all dependecies.
     this.$store.dispatch("requestBackupTask");
+    this.$store.dispatch("requestPool");
+    this.$store.dispatch("requestHost");
+    this.$store.dispatch("requestVirtualMachine");
+    this.$store.dispatch("requestStorage");
   },
   watch: {
     '$themes.success'() {

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -141,6 +141,7 @@ export default defineComponent({
   },
   mounted() {
     this.requestKeys()
+    this.$store.dispatch("requestHost", { token: this.$store.state.token });
   },
   computed: {
     areDependenciesResolved() {

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -2,16 +2,29 @@
   <div>
     <va-card>
       <va-card-title>
-        <ListHeader title="Hypervisors" plus-button-title="Add hypervisor"
-          plus-button-route="/admin/resources/hypervisors/new" :dependencies-resolved="areDependenciesResolved"
-          dependencies-message="You need to create a pool." go-button-title="Go to pools"
-          go-button-route="/admin/resources/pools" />
+        <ListHeader
+          title="Hypervisors"
+          plus-button-title="Add hypervisor"
+          plus-button-route="/admin/resources/hypervisors/new"
+          :dependencies-resolved="areDependenciesResolved"
+          dependencies-message="You need to create a pool."
+          go-button-title="Go to pools"
+          go-button-route="/admin/resources/pools"
+        />
       </va-card-title>
       <va-card-content>
-        <va-data-table :items="$store.state.resources.hostList" :columns="columns">
+        <va-data-table
+          :items="$store.state.resources.hostList"
+          :columns="columns"
+        >
           <template #cell(name)="{ value }">{{ value.toUpperCase() }}</template>
           <template #cell(pool_id)="{ value }">
-            <va-chip v-if="getPool(value)" size="small" square @click="this.$router.push('/admin/resources/pools')">
+            <va-chip
+              v-if="getPool(value)"
+              size="small"
+              square
+              @click="this.$router.push('/admin/resources/pools')"
+            >
               {{ getPool(value) }}
             </va-chip>
           </template>
@@ -21,9 +34,14 @@
             </va-chip>
           </template>
           <template #cell(ssh)="{ value }">
-            <va-chip size="small" square outline :color="value ? 'success' : 'warning'">
+            <va-chip
+              size="small"
+              square
+              outline
+              :color="value ? 'success' : 'warning'"
+            >
               <va-icon v-if="!value" name="warning" />
-              {{ JSON.parse(value) ? 'Configured' : 'Unconfigured' }}
+              {{ JSON.parse(value) ? "Configured" : "Unconfigured" }}
             </va-chip>
           </template>
           <template #cell(tags)="{ value }">
@@ -32,24 +50,48 @@
             </va-chip>
           </template>
           <template #cell(state)="{ value }">
-            <va-chip size="small" :color="value === 'Reachable' ? 'success' : 'danger'">
-              {{ value === 'Reachable' ? 'Reachable' : 'Unreachable' }}
+            <va-chip
+              size="small"
+              :color="value === 'Reachable' ? 'success' : 'danger'"
+            >
+              {{ value === "Reachable" ? "Reachable" : "Unreachable" }}
             </va-chip>
           </template>
           <template #cell(actions)="{ rowIndex }">
             <va-button-group gradient :rounded="false">
-              <va-button v-if="!$store.state.resources.hostList[rowIndex].ssh" icon="link"
+              <va-button
+                v-if="!$store.state.resources.hostList[rowIndex].ssh"
+                icon="link"
                 :disabled="sshKeys.length == 0"
-                @click="selectedHost = $store.state.resources.hostList[rowIndex], showConnectModal = true" />
-              <va-button icon="settings"
-                @click="this.$router.push(`/admin/resources/hypervisors/${$store.state.resources.hostList[rowIndex].id}`)" />
-              <va-button icon="delete"
-                @click="selectedHost = $store.state.resources.hostList[rowIndex], showDeleteModal = true" />
+                @click="
+                  (selectedHost = $store.state.resources.hostList[rowIndex]),
+                    (showConnectModal = true)
+                "
+              />
+              <va-button
+                icon="settings"
+                @click="
+                  this.$router.push(
+                    `/admin/resources/hypervisors/${$store.state.resources.hostList[rowIndex].id}`
+                  )
+                "
+              />
+              <va-button
+                icon="delete"
+                @click="
+                  (selectedHost = $store.state.resources.hostList[rowIndex]),
+                    (showDeleteModal = true)
+                "
+              />
             </va-button-group>
           </template>
         </va-data-table>
         <div v-if="!$store.state.isHostTableReady" class="flex-center ma-3">
-          <spring-spinner :animation-duration="2000" :size="30" color="#2c82e0" />
+          <spring-spinner
+            :animation-duration="2000"
+            :size="30"
+            color="#2c82e0"
+          />
         </div>
       </va-card-content>
     </va-card>
@@ -60,32 +102,51 @@
           Connecting to the hypervisor at {{ selectedHost.hostname }}
         </h2>
       </template>
-      <hr class="mb-4">
-      <va-form ref="form" @validation="validation = $event, connectHost()">
-        <va-input label="Specify the user on the server" messages="The user must have the access rights to KVM."
-          v-model="user" type="text" :rules="[value => value?.trim().length > 0 || 'Field is required']" class="mb-3" />
+      <hr class="mb-4" />
+      <va-form ref="form" @validation="(validation = $event), connectHost()">
+        <va-input
+          label="Specify the user on the server"
+          messages="The user must have the access rights to KVM."
+          v-model="user"
+          type="text"
+          :rules="[(value) => value?.trim().length > 0 || 'Field is required']"
+          class="mb-3"
+        />
         <va-tabs v-model="currentTabKey">
           <template #tabs>
             <va-tab v-for="{ name } in sshKeys" :key="name" :name="name">
               {{ name.toUpperCase() }}
             </va-tab>
           </template>
-          <div style="position: relative;">
-            <va-input label="BackROLL SSH key"
+          <div style="position: relative">
+            <va-input
+              label="BackROLL SSH key"
               messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
-              v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
-            <va-icon :name="isKeyCopied ? 'check' : 'content_copy'" :size="20" @click="copyToClipboard(currentSshKey)"
-              style="position: absolute; top: 0; right: 0; margin-top: 6px; margin-right: 4px;" />
+              v-model="currentSshKey"
+              type="textarea"
+              :autosize="true"
+              :min-rows="2"
+              readonly
+              class="mb-4"
+            />
+            <va-icon
+              :name="isKeyCopied ? 'check' : 'content_copy'"
+              :size="20"
+              @click="copyToClipboard(currentSshKey)"
+              style="
+                position: absolute;
+                top: 0;
+                right: 0;
+                margin-top: 6px;
+                margin-right: 4px;
+              "
+            />
           </div>
         </va-tabs>
         <div class="d-flex">
-          <va-button flat @click="showConnectModal = false">
-            Cancel
-          </va-button>
+          <va-button flat @click="showConnectModal = false"> Cancel </va-button>
           <va-spacer class="spacer" />
-          <va-button @click="$refs.form.validate()">
-            Done
-          </va-button>
+          <va-button @click="$refs.form.validate()"> Done </va-button>
         </div>
       </va-form>
     </va-modal>
@@ -96,24 +157,25 @@
           Removing hypervisor
         </h2>
       </template>
-      <hr>
+      <hr />
       <div>
-        You are about to remove hypervisor <b>{{ JSON.parse(JSON.stringify(this.selectedHost)).hostname }}</b>.
-        <br>Please confirm action.
+        You are about to remove hypervisor
+        <b>{{ JSON.parse(JSON.stringify(this.selectedHost)).hostname }}</b
+        >. <br />Please confirm action.
       </div>
     </va-modal>
   </div>
 </template>
 
 <script>
-import axios from 'axios'
-import { defineComponent } from 'vue'
-import * as spinners from 'epic-spinners'
+import axios from "axios";
+import { defineComponent } from "vue";
+import * as spinners from "epic-spinners";
 
-import ListHeader from "@/components/lists/ListHeader.vue"
+import ListHeader from "@/components/lists/ListHeader.vue";
 
 export default defineComponent({
-  name: 'HypervisorsTable',
+  name: "HypervisorsTable",
   components: {
     ...spinners,
     ListHeader,
@@ -121,13 +183,13 @@ export default defineComponent({
   data() {
     return {
       columns: [
-        { key: 'hostname' },
-        { key: 'pool_id', label: "Pool", sortable: true },
-        { key: 'ipaddress' },
-        { key: 'ssh', label: "SSH Connection" },
-        { key: 'tags', sortable: true },
-        { key: 'state', sortable: true },
-        { key: 'actions' }
+        { key: "hostname" },
+        { key: "pool_id", label: "Pool", sortable: true },
+        { key: "ipaddress" },
+        { key: "ssh", label: "SSH Connection" },
+        { key: "tags", sortable: true },
+        { key: "state", sortable: true },
+        { key: "actions" },
       ],
       validation: false,
       user: null,
@@ -136,41 +198,45 @@ export default defineComponent({
       isKeyCopied: false,
       showConnectModal: false,
       showDeleteModal: false,
-      selectedHost: null
-    }
+      selectedHost: null,
+    };
   },
   mounted() {
-    this.requestKeys()
+    this.requestKeys();
     this.$store.dispatch("requestHost", { token: this.$store.state.token });
   },
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.
-      return !this.$store.state.isPoolTableReady || this.$store.state.resources.poolList.length > 0;
+      return (
+        !this.$store.state.isPoolTableReady ||
+        this.$store.state.resources.poolList.length > 0
+      );
     },
     currentSshKey() {
-      return this.sshKeys.find(({ name }) => name == this.currentTabKey)?.fullLine;
+      return this.sshKeys.find(({ name }) => name == this.currentTabKey)
+        ?.fullLine;
     },
   },
   watch: {
     sshKeys(newValue) {
-      this.currentTabKey = newValue[0]?.name
+      this.currentTabKey = newValue[0]?.name;
     },
     showConnectModal(newValue, oldValue) {
       if (newValue && !oldValue) {
-        this.isKeyCopied = false
+        this.isKeyCopied = false;
       }
     },
     currentTabKey() {
-      this.isKeyCopied = false
-    }
+      this.isKeyCopied = false;
+    },
   },
   methods: {
     copyToClipboard(text) {
       // Works in HTTP (unsafe context).
 
       // Crée un élément textarea temporaire
-      const textarea = document.createElement('textarea');
+      const textarea = document.createElement("textarea");
       textarea.value = text;
 
       // Ajoute le textarea au document
@@ -181,7 +247,7 @@ export default defineComponent({
       textarea.setSelectionRange(0, 99999); // Pour les appareils mobiles
 
       // Copie le texte sélectionné dans le presse-papier
-      document.execCommand('copy');
+      document.execCommand("copy");
 
       // Supprime le textarea du document
       document.body.removeChild(textarea);
@@ -189,62 +255,104 @@ export default defineComponent({
       this.isKeyCopied = true;
     },
     getPool(id) {
-      const result = this.$store.state.resources.poolList.find(item => item.id === id)
+      const result = this.$store.state.resources.poolList.find(
+        (item) => item.id === id
+      );
       if (result) {
-        return result.name.toUpperCase()
+        return result.name.toUpperCase();
       } else {
-        return null
+        return null;
       }
     },
     connectHost() {
       if (this.validation) {
-        axios.post(`${this.$store.state.endpoint.api}/api/v1/connect/${this.selectedHost.id}`, { ip_address: this.selectedHost.ipaddress, username: this.user }, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-          .then(response => {
-            this.$store.dispatch("requestHost", { token: this.$store.state.token })
-            this.$vaToast.init({ title: response.data.state, message: `Successfully connected to ${this.selectedHost.hostname}`, color: 'success' })
-            this.showConnectModal = false
-          })
-          .catch(error => {
-            console.error(error)
+        axios
+          .post(
+            `${this.$store.state.endpoint.api}/api/v1/connect/${this.selectedHost.id}`,
+            { ip_address: this.selectedHost.ipaddress, username: this.user },
+            {
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${this.$store.state.token}`,
+              },
+            }
+          )
+          .then((response) => {
+            this.$store.dispatch("requestHost", {
+              token: this.$store.state.token,
+            });
             this.$vaToast.init({
-              title: 'Error',
-              message: error?.response?.data?.detail ?? error,
-              color: 'danger'
-            })
+              title: response.data.state,
+              message: `Successfully connected to ${this.selectedHost.hostname}`,
+              color: "success",
+            });
+            this.showConnectModal = false;
           })
+          .catch((error) => {
+            console.error(error);
+            this.$vaToast.init({
+              title: "Error",
+              message: error?.response?.data?.detail ?? error,
+              color: "danger",
+            });
+          });
       }
     },
     requestKeys() {
-      axios.get(`${this.$store.state.endpoint.api}/api/v1/publickeys`, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-        .then(response => {
-          this.sshKeys = response.data.info.map(({ name, full_line }) => ({ name, fullLine: full_line }))
+      axios
+        .get(`${this.$store.state.endpoint.api}/api/v1/publickeys`, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.$store.state.token}`,
+          },
         })
-        .catch(error => {
-          console.error(error)
+        .then((response) => {
+          this.sshKeys = response.data.info.map(({ name, full_line }) => ({
+            name,
+            fullLine: full_line,
+          }));
+        })
+        .catch((error) => {
+          console.error(error);
           this.$vaToast.init({
-            title: 'Unable to retrieve BackROLL SSH keys',
+            title: "Unable to retrieve BackROLL SSH keys",
             message: error?.response?.data?.detail ?? error,
-            color: 'danger'
-          })
-        })
+            color: "danger",
+          });
+        });
     },
     deleteHost() {
-      axios.delete(`${this.$store.state.endpoint.api}/api/v1/hosts/${this.selectedHost.id}`, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-        .then(response => {
-          this.$store.dispatch("requestHost", { token: this.$store.state.token })
-          this.$vaToast.init({ title: response.data.state, message: 'Hypervisor has been successfully deleted', color: 'success' })
-        })
-        .catch(error => {
-          console.error(error)
+      axios
+        .delete(
+          `${this.$store.state.endpoint.api}/api/v1/hosts/${this.selectedHost.id}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${this.$store.state.token}`,
+            },
+          }
+        )
+        .then((response) => {
+          this.$store.dispatch("requestHost", {
+            token: this.$store.state.token,
+          });
           this.$vaToast.init({
-            title: 'Unable to delete Hypervisor',
-            message: error?.response?.data?.detail ?? error,
-            color: 'danger'
-          })
+            title: response.data.state,
+            message: "Hypervisor has been successfully deleted",
+            color: "success",
+          });
         })
-    }
-  }
-})
+        .catch((error) => {
+          console.error(error);
+          this.$vaToast.init({
+            title: "Unable to delete Hypervisor",
+            message: error?.response?.data?.detail ?? error,
+            color: "danger",
+          });
+        });
+    },
+  },
+});
 </script>
 <style scoped>
 .text-right {

--- a/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
+++ b/src/ui/src/pages/admin/resources/hypervisors/HypervisorList.vue
@@ -2,29 +2,16 @@
   <div>
     <va-card>
       <va-card-title>
-        <ListHeader
-          title="Hypervisors"
-          plus-button-title="Add hypervisor"
-          plus-button-route="/admin/resources/hypervisors/new"
-          :dependencies-resolved="areDependenciesResolved"
-          dependencies-message="You need to create a pool."
-          go-button-title="Go to pools"
-          go-button-route="/admin/resources/pools"
-        />
+        <ListHeader title="Hypervisors" plus-button-title="Add hypervisor"
+          plus-button-route="/admin/resources/hypervisors/new" :dependencies-resolved="areDependenciesResolved"
+          dependencies-message="You need to create a pool." go-button-title="Go to pools"
+          go-button-route="/admin/resources/pools" />
       </va-card-title>
       <va-card-content>
-        <va-data-table
-          :items="$store.state.resources.hostList"
-          :columns="columns"
-        >
+        <va-data-table :items="$store.state.resources.hostList" :columns="columns">
           <template #cell(name)="{ value }">{{ value.toUpperCase() }}</template>
           <template #cell(pool_id)="{ value }">
-            <va-chip
-              v-if="getPool(value)"
-              size="small"
-              square
-              @click="this.$router.push('/admin/resources/pools')"
-            >
+            <va-chip v-if="getPool(value)" size="small" square @click="this.$router.push('/admin/resources/pools')">
               {{ getPool(value) }}
             </va-chip>
           </template>
@@ -34,12 +21,7 @@
             </va-chip>
           </template>
           <template #cell(ssh)="{ value }">
-            <va-chip
-              size="small"
-              square
-              outline
-              :color="value ? 'success' : 'warning'"
-            >
+            <va-chip size="small" square outline :color="value ? 'success' : 'warning'">
               <va-icon v-if="!value" name="warning" />
               {{ JSON.parse(value) ? "Configured" : "Unconfigured" }}
             </va-chip>
@@ -50,48 +32,31 @@
             </va-chip>
           </template>
           <template #cell(state)="{ value }">
-            <va-chip
-              size="small"
-              :color="value === 'Reachable' ? 'success' : 'danger'"
-            >
+            <va-chip size="small" :color="value === 'Reachable' ? 'success' : 'danger'">
               {{ value === "Reachable" ? "Reachable" : "Unreachable" }}
             </va-chip>
           </template>
           <template #cell(actions)="{ rowIndex }">
             <va-button-group gradient :rounded="false">
-              <va-button
-                v-if="!$store.state.resources.hostList[rowIndex].ssh"
-                icon="link"
-                :disabled="sshKeys.length == 0"
-                @click="
+              <va-button v-if="!$store.state.resources.hostList[rowIndex].ssh" icon="link"
+                :disabled="sshKeys.length == 0" @click="
                   (selectedHost = $store.state.resources.hostList[rowIndex]),
-                    (showConnectModal = true)
-                "
-              />
-              <va-button
-                icon="settings"
-                @click="
-                  this.$router.push(
-                    `/admin/resources/hypervisors/${$store.state.resources.hostList[rowIndex].id}`
-                  )
-                "
-              />
-              <va-button
-                icon="delete"
-                @click="
-                  (selectedHost = $store.state.resources.hostList[rowIndex]),
-                    (showDeleteModal = true)
-                "
-              />
+                  (showConnectModal = true)
+                  " />
+              <va-button icon="settings" @click="
+                this.$router.push(
+                  `/admin/resources/hypervisors/${$store.state.resources.hostList[rowIndex].id}`
+                )
+                " />
+              <va-button icon="delete" @click="
+                (selectedHost = $store.state.resources.hostList[rowIndex]),
+                (showDeleteModal = true)
+                " />
             </va-button-group>
           </template>
         </va-data-table>
         <div v-if="!$store.state.isHostTableReady" class="flex-center ma-3">
-          <spring-spinner
-            :animation-duration="2000"
-            :size="30"
-            color="#2c82e0"
-          />
+          <spring-spinner :animation-duration="2000" :size="30" color="#2c82e0" />
         </div>
       </va-card-content>
     </va-card>
@@ -104,14 +69,9 @@
       </template>
       <hr class="mb-4" />
       <va-form ref="form" @validation="(validation = $event), connectHost()">
-        <va-input
-          label="Specify the user on the server"
-          messages="The user must have the access rights to KVM."
-          v-model="user"
-          type="text"
-          :rules="[(value) => value?.trim().length > 0 || 'Field is required']"
-          class="mb-3"
-        />
+        <va-input label="Specify the user on the server" messages="The user must have the access rights to KVM."
+          v-model="user" type="text" :rules="[(value) => value?.trim().length > 0 || 'Field is required']"
+          class="mb-3" />
         <va-tabs v-model="currentTabKey">
           <template #tabs>
             <va-tab v-for="{ name } in sshKeys" :key="name" :name="name">
@@ -119,28 +79,17 @@
             </va-tab>
           </template>
           <div style="position: relative">
-            <va-input
-              label="BackROLL SSH key"
+            <va-input label="BackROLL SSH key"
               messages="Copy-paste one of the keys into the ~/.ssh/authorized_keys file on the server."
-              v-model="currentSshKey"
-              type="textarea"
-              :autosize="true"
-              :min-rows="2"
-              readonly
-              class="mb-4"
-            />
-            <va-icon
-              :name="isKeyCopied ? 'check' : 'content_copy'"
-              :size="20"
-              @click="copyToClipboard(currentSshKey)"
+              v-model="currentSshKey" type="textarea" :autosize="true" :min-rows="2" readonly class="mb-4" />
+            <va-icon :name="isKeyCopied ? 'check' : 'content_copy'" :size="20" @click="copyToClipboard(currentSshKey)"
               style="
                 position: absolute;
                 top: 0;
                 right: 0;
                 margin-top: 6px;
                 margin-right: 4px;
-              "
-            />
+              " />
           </div>
         </va-tabs>
         <div class="d-flex">
@@ -160,8 +109,7 @@
       <hr />
       <div>
         You are about to remove hypervisor
-        <b>{{ JSON.parse(JSON.stringify(this.selectedHost)).hostname }}</b
-        >. <br />Please confirm action.
+        <b>{{ JSON.parse(JSON.stringify(this.selectedHost)).hostname }}</b>. <br />Please confirm action.
       </div>
     </va-modal>
   </div>
@@ -200,10 +148,6 @@ export default defineComponent({
       showDeleteModal: false,
       selectedHost: null,
     };
-  },
-  mounted() {
-    this.requestKeys();
-    this.$store.dispatch("requestHost", { token: this.$store.state.token });
   },
   computed: {
     areDependenciesResolved() {
@@ -351,6 +295,10 @@ export default defineComponent({
           });
         });
     },
+  },
+  mounted() {
+    this.requestKeys();
+    this.$store.dispatch("requestHost");
   },
 });
 </script>

--- a/src/ui/src/pages/admin/resources/pools/PoolList.vue
+++ b/src/ui/src/pages/admin/resources/pools/PoolList.vue
@@ -1,30 +1,59 @@
 <template>
   <va-card>
     <va-card-title>
-      <ListHeader title="pools" plus-button-title="Create pool" plus-button-route="/admin/resources/pools/new"
-        :dependencies-resolved="areDependenciesResolved" dependencies-message="You need to create a backup policy."
-        go-button-title="Go to policies" go-button-route="/admin/configuration/policies" />
+      <ListHeader
+        title="pools"
+        plus-button-title="Create pool"
+        plus-button-route="/admin/resources/pools/new"
+        :dependencies-resolved="areDependenciesResolved"
+        dependencies-message="You need to create a backup policy."
+        go-button-title="Go to policies"
+        go-button-route="/admin/configuration/policies"
+      />
     </va-card-title>
     <va-card-content>
-      <va-data-table :items="$store.state.resources.poolList" :columns="columns">
+      <va-data-table
+        :items="$store.state.resources.poolList"
+        :columns="columns"
+      >
         <template #cell(name)="{ value }">{{ value.toUpperCase() }}</template>
         <template #cell(policy_id)="{ value }">
-          <va-chip size="small" square @click="this.$router.push('/admin/configuration/policies')">
+          <va-chip
+            size="small"
+            square
+            @click="this.$router.push('/admin/configuration/policies')"
+          >
             {{ getBackupPolicy(value).name.toUpperCase() }}
           </va-chip>
         </template>
         <template #cell(connector_id)="{ value }">
-          <va-chip v-if="getConnector(value)" size="small" color="#7f1f90" square
-            @click="this.$router.push('/admin/configuration/connectors')">
+          <va-chip
+            v-if="getConnector(value)"
+            size="small"
+            color="#7f1f90"
+            square
+            @click="this.$router.push('/admin/configuration/connectors')"
+          >
             {{ getConnector(value) }}
           </va-chip>
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button icon="settings"
-              @click="this.$router.push(`/admin/resources/pools/${$store.state.resources.poolList[rowIndex].id}`)" />
-            <va-button icon="delete"
-              @click="selectedPool = $store.state.resources.poolList[rowIndex], showDeleteModal = !showDeleteModal" />
+            <va-button
+              icon="settings"
+              @click="
+                this.$router.push(
+                  `/admin/resources/pools/${$store.state.resources.poolList[rowIndex].id}`
+                )
+              "
+            />
+            <va-button
+              icon="delete"
+              @click="
+                (selectedPool = $store.state.resources.poolList[rowIndex]),
+                  (showDeleteModal = !showDeleteModal)
+              "
+            />
           </va-button-group>
         </template>
       </va-data-table>
@@ -40,23 +69,24 @@
         Removing Pool
       </h2>
     </template>
-    <hr>
+    <hr />
     <div>
-      You are about to remove Pool <b>{{ JSON.parse(JSON.stringify(this.selectedPool)).name }}</b>.
-      <br>Please confirm action.
+      You are about to remove Pool
+      <b>{{ JSON.parse(JSON.stringify(this.selectedPool)).name }}</b
+      >. <br />Please confirm action.
     </div>
   </va-modal>
 </template>
 
 <script>
-import axios from 'axios'
-import { defineComponent } from 'vue'
-import * as spinners from 'epic-spinners'
+import axios from "axios";
+import { defineComponent } from "vue";
+import * as spinners from "epic-spinners";
 
-import ListHeader from "@/components/lists/ListHeader.vue"
+import ListHeader from "@/components/lists/ListHeader.vue";
 
 export default defineComponent({
-  name: 'PoolsTable',
+  name: "PoolsTable",
   components: {
     ...spinners,
     ListHeader,
@@ -64,72 +94,95 @@ export default defineComponent({
   data() {
     return {
       columns: [
-        { key: 'name' },
-        { key: 'policy_id', label: "Assigned policy" },
-        { key: 'connector_id', label: "Connector" },
-        { key: 'actions' }
+        { key: "name" },
+        { key: "policy_id", label: "Assigned policy" },
+        { key: "connector_id", label: "Connector" },
+        { key: "actions" },
       ],
       showDeleteModal: false,
-      selectedPool: null
-    }
+      selectedPool: null,
+    };
   },
   mounted() {
-  this.$store.dispatch("requestPool", { token: this.$store.state.token });
+    this.$store.dispatch("requestPool", { token: this.$store.state.token });
   },
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.
-      return !this.$store.state.isPolicyTableReady || this.$store.state.resources.policyList.length > 0;
-    }
+      return (
+        !this.$store.state.isPolicyTableReady ||
+        this.$store.state.resources.policyList.length > 0
+      );
+    },
   },
   methods: {
     getConnector(id) {
-      const result = this.$store.state.resources.connectorList.find(item => item.id === id)
+      const result = this.$store.state.resources.connectorList.find(
+        (item) => item.id === id
+      );
       if (result) {
-        return result.name.toUpperCase()
+        return result.name.toUpperCase();
       } else {
-        return null
+        return null;
       }
     },
     deletePool() {
-      axios.delete(`${this.$store.state.endpoint.api}/api/v1/pools/${this.selectedPool.id}`, { headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.$store.state.token}` } })
-        .then(response => {
-          this.$store.dispatch("requestPool", { token: this.$store.state.token })
-          this.$vaToast.init({ title: response.data.state, message: 'Pool has been successfully deleted', color: 'success' })
-        })
-        .catch(error => {
-          console.error(error)
+      axios
+        .delete(
+          `${this.$store.state.endpoint.api}/api/v1/pools/${this.selectedPool.id}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${this.$store.state.token}`,
+            },
+          }
+        )
+        .then((response) => {
+          this.$store.dispatch("requestPool", {
+            token: this.$store.state.token,
+          });
           this.$vaToast.init({
-            title: 'Unable to delete pool',
-            message: error?.response?.data?.detail ?? error,
-            color: 'danger'
-          })
+            title: response.data.state,
+            message: "Pool has been successfully deleted",
+            color: "success",
+          });
         })
+        .catch((error) => {
+          console.error(error);
+          this.$vaToast.init({
+            title: "Unable to delete pool",
+            message: error?.response?.data?.detail ?? error,
+            color: "danger",
+          });
+        });
     },
     humanPoolsSize(bytes, si = false, dp = 1) {
       const thresh = si ? 1000 : 1024;
       if (Math.abs(bytes) < thresh) {
-        return bytes + ' B';
+        return bytes + " B";
       }
       const units = si
-        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+        ? ["kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        : ["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
       let u = -1;
       const r = 10 ** dp;
       do {
         bytes /= thresh;
         ++u;
-      } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
-      return bytes.toFixed(dp) + ' ' + units[u];
+      } while (
+        Math.round(Math.abs(bytes) * r) / r >= thresh &&
+        u < units.length - 1
+      );
+      return bytes.toFixed(dp) + " " + units[u];
     },
     getBackupPolicy(id) {
       const result = this.$store.state.resources.policyList.filter((item) => {
-        return item.id == id
-      })
-      return result[0]
-    }
-  }
-})
+        return item.id == id;
+      });
+      return result[0];
+    },
+  },
+});
 </script>
 <style scoped>
 .text-right {

--- a/src/ui/src/pages/admin/resources/pools/PoolList.vue
+++ b/src/ui/src/pages/admin/resources/pools/PoolList.vue
@@ -73,6 +73,9 @@ export default defineComponent({
       selectedPool: null
     }
   },
+  mounted() {
+  this.$store.dispatch("requestPool", { token: this.$store.state.token });
+  },
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.

--- a/src/ui/src/pages/admin/resources/pools/PoolList.vue
+++ b/src/ui/src/pages/admin/resources/pools/PoolList.vue
@@ -1,59 +1,35 @@
 <template>
   <va-card>
     <va-card-title>
-      <ListHeader
-        title="pools"
-        plus-button-title="Create pool"
-        plus-button-route="/admin/resources/pools/new"
-        :dependencies-resolved="areDependenciesResolved"
-        dependencies-message="You need to create a backup policy."
-        go-button-title="Go to policies"
-        go-button-route="/admin/configuration/policies"
-      />
+      <ListHeader title="pools" plus-button-title="Create pool" plus-button-route="/admin/resources/pools/new"
+        :dependencies-resolved="areDependenciesResolved" dependencies-message="You need to create a backup policy."
+        go-button-title="Go to policies" go-button-route="/admin/configuration/policies" />
     </va-card-title>
     <va-card-content>
-      <va-data-table
-        :items="$store.state.resources.poolList"
-        :columns="columns"
-      >
+      <va-data-table :items="$store.state.resources.poolList" :columns="columns">
         <template #cell(name)="{ value }">{{ value.toUpperCase() }}</template>
         <template #cell(policy_id)="{ value }">
-          <va-chip
-            size="small"
-            square
-            @click="this.$router.push('/admin/configuration/policies')"
-          >
+          <va-chip size="small" square @click="this.$router.push('/admin/configuration/policies')">
             {{ getBackupPolicy(value).name.toUpperCase() }}
           </va-chip>
         </template>
         <template #cell(connector_id)="{ value }">
-          <va-chip
-            v-if="getConnector(value)"
-            size="small"
-            color="#7f1f90"
-            square
-            @click="this.$router.push('/admin/configuration/connectors')"
-          >
+          <va-chip v-if="getConnector(value)" size="small" color="#7f1f90" square
+            @click="this.$router.push('/admin/configuration/connectors')">
             {{ getConnector(value) }}
           </va-chip>
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button
-              icon="settings"
-              @click="
-                this.$router.push(
-                  `/admin/resources/pools/${$store.state.resources.poolList[rowIndex].id}`
-                )
-              "
-            />
-            <va-button
-              icon="delete"
-              @click="
-                (selectedPool = $store.state.resources.poolList[rowIndex]),
-                  (showDeleteModal = !showDeleteModal)
-              "
-            />
+            <va-button icon="settings" @click="
+              this.$router.push(
+                `/admin/resources/pools/${$store.state.resources.poolList[rowIndex].id}`
+              )
+              " />
+            <va-button icon="delete" @click="
+              (selectedPool = $store.state.resources.poolList[rowIndex]),
+              (showDeleteModal = !showDeleteModal)
+              " />
           </va-button-group>
         </template>
       </va-data-table>
@@ -72,8 +48,7 @@
     <hr />
     <div>
       You are about to remove Pool
-      <b>{{ JSON.parse(JSON.stringify(this.selectedPool)).name }}</b
-      >. <br />Please confirm action.
+      <b>{{ JSON.parse(JSON.stringify(this.selectedPool)).name }}</b>. <br />Please confirm action.
     </div>
   </va-modal>
 </template>
@@ -102,9 +77,6 @@ export default defineComponent({
       showDeleteModal: false,
       selectedPool: null,
     };
-  },
-  mounted() {
-    this.$store.dispatch("requestPool", { token: this.$store.state.token });
   },
   computed: {
     areDependenciesResolved() {
@@ -181,6 +153,9 @@ export default defineComponent({
       });
       return result[0];
     },
+  },
+  mounted() {
+    this.$store.dispatch("requestPool");
   },
 });
 </script>

--- a/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineDetails.vue
+++ b/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineDetails.vue
@@ -11,6 +11,7 @@
               :text="virtualMachine.state" />
           </div>
         </div>
+        <va-button icon="clear" color="info" @click="$router.go(-1)">Close</va-button>
       </va-card-title>
       <va-card-content>
         <va-tabs v-model="selectedTab" grow>

--- a/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineDetails.vue
+++ b/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineDetails.vue
@@ -58,10 +58,11 @@
               STORAGE
             </span>
           </va-divider>
-          <div v-if="loadingStorage" class="flex-center ma-3">
+          <!-- <div v-if="loadingStorage" class="flex-center ma-3">
             <looping-rhombuses-spinner :animation-duration="1500" :size="50" color="#2c82e0" />
           </div>
-          <va-data-table v-else class="mb-4" :items="storageList" :columns="[
+          <va-data-table v-else class="mb-4" :items="storageList" :columns="[ -->
+          <va-data-table class="mb-4" :items="storageList" :columns="[
             { key: 'device', sortable: true },
             { key: 'source', sortable: true },
             { key: 'formattedStatus', label: 'status', sortable: true }]">
@@ -93,10 +94,11 @@
           </va-button>
         </div>
         <div v-else-if="selectedTab === 'save'" style="padding-top: 1%;">
-          <div v-if="loadingBackups" class="flex-center ma-3">
+          <!-- <div v-if="loadingBackups" class="flex-center ma-3">
             <scaling-squares-spinner :animation-duration="1500" :size="85" color="#2c82e0" />
           </div>
-          <div v-else>
+          <div v-else> -->
+          <div>
             <div class="row">
               <div class="flex xs6">
                 <div class="item">
@@ -228,6 +230,8 @@ export default defineComponent({
       storageList: [],
       loadingStorage: false,
       storageErrorToShow: null,
+      lastMostRecentBackup: null, // Used to track changes in most recent backup during the loading
+      lastOldestBackup: null, // Used to track changes in oldest backup during the loading
     }
   },
   watch: {
@@ -271,27 +275,20 @@ export default defineComponent({
       return ((this.virtualMachine.mem / 1024) / 1024).toFixed(0)
     },
     mostRecentBackup() {
-      if (!this.loadingBackups) {
-        if (this.backupInfo.archives.length > 0) {
-          return new Date(Math.max(...this.backupInfo.archives.map(e => new Date(e.start)))).toLocaleDateString()
-        } else {
-          return "N/A"
-        }
+      if (this.backupInfo.archives.length > 0) {
+        return new Date(Math.max(...this.backupInfo.archives.map(e => new Date(e.start)))).toLocaleDateString()
       } else {
         return "N/A"
       }
     },
-    oldestBackup() {
-      if (!this.loadingBackups) {
-        if (this.backupInfo.archives.length > 0) {
-          return new Date(Math.min(...this.backupInfo.archives.map(e => new Date(e.start)))).toLocaleDateString()
-        } else {
-          return "N/A"
-        }
-      } else {
-        return "N/A"
-      }
-    },
+  oldestBackup() {
+    if (this.backupInfo.archives.length > 0) {
+      const value = new Date(Math.min(...this.backupInfo.archives.map(e => new Date(e.start)))).toLocaleDateString()
+      this.lastOldestBackup = value
+      return value
+    }
+    return this.lastOldestBackup || "N/A"
+  },
     pages() {
       return (this.perPage && this.perPage !== 0)
         ? Math.ceil(this.backupInfo.archives.length / this.perPage)

--- a/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
+++ b/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
@@ -1,36 +1,18 @@
 <template>
   <va-card>
     <va-card-title>
-      <ListHeader
-        title="Virtual machines"
-        :dependencies-resolved="areDependenciesResolved"
-        dependencies-message="You need to add an hypervisor."
-        go-button-title="Go to hypervisors"
-        go-button-route="/admin/resources/hypervisors"
-      />
+      <ListHeader title="Virtual machines" :dependencies-resolved="areDependenciesResolved"
+        dependencies-message="You need to add an hypervisor." go-button-title="Go to hypervisors"
+        go-button-route="/admin/resources/hypervisors" />
     </va-card-title>
     <va-card-content>
       <div class="row">
-        <va-input
-          class="flex mb-2 md6"
-          placeholder="Filter..."
-          v-model="filter"
-        />
-        <va-checkbox
-          class="flex mb-2 md6"
-          label="Look for an exact match"
-          v-model="useCustomFilteringFn"
-        />
+        <va-input class="flex mb-2 md6" placeholder="Filter..." v-model="filter" />
+        <va-checkbox class="flex mb-2 md6" label="Look for an exact match" v-model="useCustomFilteringFn" />
       </div>
-      <va-data-table
-        :current-page="currentPage"
-        :per-page="perPage"
-        :items="$store.state.resources.vmList"
-        :columns="columns"
-        :filter="filter"
-        :filter-method="customFilteringFn"
-        @filtered="filteredCount = $event.items.length"
-      >
+      <va-data-table :current-page="currentPage" :per-page="perPage" :items="$store.state.resources.vmList"
+        :columns="columns" :filter="filter" :filter-method="customFilteringFn"
+        @filtered="filteredCount = $event.items.length">
         <template #header(cpus)>CPU</template>
         <template #header(mem)>Memory</template>
         <template #header(host)>Hypervisor</template>
@@ -46,12 +28,7 @@
           </va-chip>
         </template>
         <template #cell(host)="{ value }">
-          <va-chip
-            v-if="value"
-            size="small"
-            square
-            @click="this.$router.push('/admin/resources/hypervisors')"
-          >
+          <va-chip v-if="value" size="small" square @click="this.$router.push('/admin/resources/hypervisors')">
             {{ getHost(value).hostname }}
           </va-chip>
         </template>
@@ -61,10 +38,7 @@
           </va-chip>
         </template>
         <template #cell(state)="{ value }">
-          <va-chip
-            size="small"
-            :color="value === 'Running' ? 'success' : 'dark'"
-          >
+          <va-chip size="small" :color="value === 'Running' ? 'success' : 'dark'">
             <va-icon :name="value === 'Running' ? 'bolt' : 'power_off'" />
             <span style="padding-left: 5px">
               {{ value }}
@@ -73,26 +47,17 @@
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button
-              icon="info"
-              @click="
-                this.$router.push(
-                  `/resources/virtualmachines/${$store.state.resources.vmList[rowIndex].uuid}`
-                )
-              "
-            />
+            <va-button icon="info" @click="
+              this.$router.push(
+                `/resources/virtualmachines/${$store.state.resources.vmList[rowIndex].uuid}`
+              )
+              " />
           </va-button-group>
         </template>
         <template #bodyAppend>
           <tr>
             <td colspan="8" class="table-example--pagination">
-              <va-pagination
-                v-model="currentPage"
-                input
-                :pages="pages"
-                size="small"
-                flat
-              />
+              <va-pagination v-model="currentPage" input :pages="pages" size="small" flat />
             </td>
           </tr>
         </template>
@@ -166,6 +131,9 @@ export default defineComponent({
       });
       return result[0];
     },
+  },
+  mounted() {
+    this.$store.dispatch("requestVirtualMachine");
   },
 });
 </script>

--- a/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
+++ b/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
@@ -49,7 +49,7 @@
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button icon="settings"
+            <va-button icon="info"
               @click="this.$router.push(`/resources/virtualmachines/${$store.state.resources.vmList[rowIndex].uuid}`)" />
           </va-button-group>
         </template>

--- a/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
+++ b/src/ui/src/pages/admin/resources/virtualmachines/VirtualMachineList.vue
@@ -1,18 +1,36 @@
 <template>
   <va-card>
     <va-card-title>
-      <ListHeader title="Virtual machines" :dependencies-resolved="areDependenciesResolved"
-        dependencies-message="You need to add an hypervisor." go-button-title="Go to hypervisors"
-        go-button-route="/admin/resources/hypervisors" />
+      <ListHeader
+        title="Virtual machines"
+        :dependencies-resolved="areDependenciesResolved"
+        dependencies-message="You need to add an hypervisor."
+        go-button-title="Go to hypervisors"
+        go-button-route="/admin/resources/hypervisors"
+      />
     </va-card-title>
     <va-card-content>
       <div class="row">
-        <va-input class="flex mb-2 md6" placeholder="Filter..." v-model="filter" />
-        <va-checkbox class="flex mb-2 md6" label="Look for an exact match" v-model="useCustomFilteringFn" />
+        <va-input
+          class="flex mb-2 md6"
+          placeholder="Filter..."
+          v-model="filter"
+        />
+        <va-checkbox
+          class="flex mb-2 md6"
+          label="Look for an exact match"
+          v-model="useCustomFilteringFn"
+        />
       </div>
-      <va-data-table :current-page="currentPage" :per-page="perPage" :items="$store.state.resources.vmList"
-        :columns="columns" :filter="filter" :filter-method="customFilteringFn"
-        @filtered="filteredCount = $event.items.length">
+      <va-data-table
+        :current-page="currentPage"
+        :per-page="perPage"
+        :items="$store.state.resources.vmList"
+        :columns="columns"
+        :filter="filter"
+        :filter-method="customFilteringFn"
+        @filtered="filteredCount = $event.items.length"
+      >
         <template #header(cpus)>CPU</template>
         <template #header(mem)>Memory</template>
         <template #header(host)>Hypervisor</template>
@@ -20,17 +38,20 @@
         <template #header(ssh)>SSH Connection</template>
         <template #cell(name)="{ value }">{{ value.toUpperCase() }}</template>
         <template #cell(cpus)="{ value }">
-          <va-chip size="small" square outline>
-            {{ value }} Cores
-          </va-chip>
+          <va-chip size="small" square outline> {{ value }} Cores </va-chip>
         </template>
         <template #cell(mem)="{ value }">
           <va-chip size="small" square outline>
-            {{ ((value / 1024) / 1024).toFixed(0) }} GiB
+            {{ (value / 1024 / 1024).toFixed(0) }} GiB
           </va-chip>
         </template>
         <template #cell(host)="{ value }">
-          <va-chip v-if="value" size="small" square @click="this.$router.push('/admin/resources/hypervisors')">
+          <va-chip
+            v-if="value"
+            size="small"
+            square
+            @click="this.$router.push('/admin/resources/hypervisors')"
+          >
             {{ getHost(value).hostname }}
           </va-chip>
         </template>
@@ -40,23 +61,38 @@
           </va-chip>
         </template>
         <template #cell(state)="{ value }">
-          <va-chip size="small" :color="value === 'Running' ? 'success' : 'dark'">
+          <va-chip
+            size="small"
+            :color="value === 'Running' ? 'success' : 'dark'"
+          >
             <va-icon :name="value === 'Running' ? 'bolt' : 'power_off'" />
-            <span style="padding-left: 5px;">
+            <span style="padding-left: 5px">
               {{ value }}
             </span>
           </va-chip>
         </template>
         <template #cell(actions)="{ rowIndex }">
           <va-button-group gradient :rounded="false">
-            <va-button icon="info"
-              @click="this.$router.push(`/resources/virtualmachines/${$store.state.resources.vmList[rowIndex].uuid}`)" />
+            <va-button
+              icon="info"
+              @click="
+                this.$router.push(
+                  `/resources/virtualmachines/${$store.state.resources.vmList[rowIndex].uuid}`
+                )
+              "
+            />
           </va-button-group>
         </template>
         <template #bodyAppend>
           <tr>
             <td colspan="8" class="table-example--pagination">
-              <va-pagination v-model="currentPage" input :pages="pages" size="small" flat />
+              <va-pagination
+                v-model="currentPage"
+                input
+                :pages="pages"
+                size="small"
+                flat
+              />
             </td>
           </tr>
         </template>
@@ -69,66 +105,69 @@
 </template>
 
 <script>
-import { defineComponent } from 'vue'
-import * as spinners from 'epic-spinners'
+import { defineComponent } from "vue";
+import * as spinners from "epic-spinners";
 
-import ListHeader from '@/components/lists/ListHeader.vue'
+import ListHeader from "@/components/lists/ListHeader.vue";
 
 export default defineComponent({
-  name: 'VMsTable',
+  name: "VMsTable",
   components: {
     ...spinners,
-    ListHeader
+    ListHeader,
   },
   data() {
     return {
       columns: [
-        { key: 'name', sortable: true },
-        { key: 'cpus', sortable: true },
-        { key: 'mem', sortable: true },
-        { key: 'host', sortable: true },
-        { key: 'host_tag', sortable: true },
-        { key: 'state', sortable: true },
-        { key: 'actions' }
+        { key: "name", sortable: true },
+        { key: "cpus", sortable: true },
+        { key: "mem", sortable: true },
+        { key: "host", sortable: true },
+        { key: "host_tag", sortable: true },
+        { key: "state", sortable: true },
+        { key: "actions" },
       ],
       selectedHost: null,
       perPage: 25,
       currentPage: 1,
-      filter: '',
+      filter: "",
       useCustomFilteringFn: false,
-      filteredCount: this.$store.state.resources.vmList.length
-    }
+      filteredCount: this.$store.state.resources.vmList.length,
+    };
   },
   computed: {
     areDependenciesResolved() {
       // Prevent showing irrelevant alert by checking if the table is ready.
-      return !this.$store.state.isHostTableReady || this.$store.state.resources.hostList.length > 0;
+      return (
+        !this.$store.state.isHostTableReady ||
+        this.$store.state.resources.hostList.length > 0
+      );
     },
     pages() {
-      return (this.perPage && this.perPage !== 0)
+      return this.perPage && this.perPage !== 0
         ? Math.ceil(this.$store.state.resources.vmList.length / this.perPage)
-        : this.filtered.length
+        : this.filtered.length;
     },
     customFilteringFn() {
-      return this.useCustomFilteringFn ? this.filterExact : undefined
-    }
+      return this.useCustomFilteringFn ? this.filterExact : undefined;
+    },
   },
   methods: {
     filterExact(source) {
-      if (this.filter === '') {
-        return true
+      if (this.filter === "") {
+        return true;
       }
 
-      return source?.toString?.() === this.filter
+      return source?.toString?.() === this.filter;
     },
     getHost(id) {
       const result = this.$store.state.resources.hostList.filter((item) => {
-        return item.id == id
-      })
-      return result[0]
-    }
-  }
-})
+        return item.id == id;
+      });
+      return result[0];
+    },
+  },
+});
 </script>
 <style scoped>
 .text-right {

--- a/src/ui/src/pages/admin/tasks/backup/Backup.vue
+++ b/src/ui/src/pages/admin/tasks/backup/Backup.vue
@@ -41,5 +41,8 @@ export default defineComponent({
       }
     }
   },
+  mounted() {
+    this.$store.dispatch("requestBackupTask");
+  },
 })
 </script>

--- a/src/ui/src/pages/admin/tasks/backup/Backup.vue
+++ b/src/ui/src/pages/admin/tasks/backup/Backup.vue
@@ -16,6 +16,9 @@ export default defineComponent({
     TaskTable,
     TaskPage
   },
+  mounted() {
+    this.$store.dispatch("requestBackupTask", { token: this.$store.state.token });
+  },
   computed: {
     getTaskList() {
       return (taskFilter) => {

--- a/src/ui/src/pages/admin/tasks/backup/Backup.vue
+++ b/src/ui/src/pages/admin/tasks/backup/Backup.vue
@@ -16,9 +16,6 @@ export default defineComponent({
     TaskTable,
     TaskPage
   },
-  mounted() {
-    this.$store.dispatch("requestBackupTask", { token: this.$store.state.token });
-  },
   computed: {
     getTaskList() {
       return (taskFilter) => {

--- a/src/ui/src/pages/admin/tasks/restore/Restore.vue
+++ b/src/ui/src/pages/admin/tasks/restore/Restore.vue
@@ -39,5 +39,8 @@ export default defineComponent({
       }
     },
   },
+  mounted() {
+    this.$store.dispatch("requestRestoreTask");
+  },
 })
 </script>

--- a/src/ui/src/pages/auth/Login.vue
+++ b/src/ui/src/pages/auth/Login.vue
@@ -1,13 +1,8 @@
 <template>
   <div class="login-wrapper">
     <h1 class="login-title">Welcome to</h1>
-    <img
-      class="va-icon-vuestic logo"
-      height="80"
-      style="margin-bottom: 2rem"
-      src="/img/logo2-deg-backroll-cropped.9feb6084.svg"
-      data-v-45c0bfaf=""
-    />
+    <img class="va-icon-vuestic logo" height="80" style="margin-bottom: 2rem"
+      src="/img/logo2-deg-backroll-cropped.9feb6084.svg" data-v-45c0bfaf="" />
     <va-card class="login-form">
       <va-card-title>
         <h1>Please login to continue</h1>
@@ -15,20 +10,14 @@
       <va-card-content>
         <va-form ref="form" @submit.prevent="submit">
           <va-input class="mb-3" label="Username" v-model="username" />
-          <va-input
-            class="mb-3"
-            label="Password"
-            v-model="password"
-            type="password"
-            @keydown.enter.prevent="submitOnEnter"
-          />
+          <va-input class="mb-3" label="Password" v-model="password" type="password"
+            @keydown.enter.prevent="submitOnEnter" />
         </va-form>
         <va-button class="mb-3" @click="submit">
           {{ "Login" }}
         </va-button>
         <div class="links">
-          <a href="#">Forgot password?</a
-          ><!-- TODO -->
+          <a href="#">Forgot password?</a><!-- TODO -->
         </div>
       </va-card-content>
     </va-card>
@@ -73,15 +62,6 @@ export default defineComponent({
       password: "",
     };
   },
-  mounted() {
-    if (this.$store.state.token) {
-      this.$store.dispatch("requestConnector");
-      this.$store.dispatch("requestPool");
-      this.$store.dispatch("requestHost");
-      this.$store.dispatch("requestPolicy");
-      this.$store.dispatch("requestStorage");
-    }
-  },
   methods: {
     async submit() {
       if (this.$refs.form.validate()) {
@@ -106,11 +86,23 @@ export default defineComponent({
           message: "You are logged in.",
           color: "success",
         });
-        this.$store.dispatch("requestConnector");
+
+        // Initial loading for a better experience
+        // when first opening a list.
+
+        this.$store.dispatch("requestJob");
+        this.$store.dispatch("requestBackupTask");
+        this.$store.dispatch("requestRestoreTask");
+
         this.$store.dispatch("requestPool");
         this.$store.dispatch("requestHost");
+        this.$store.dispatch("requestVirtualMachine");
+
         this.$store.dispatch("requestPolicy");
         this.$store.dispatch("requestStorage");
+        this.$store.dispatch("requestConnector");
+        this.$store.dispatch("requestExternalHook")
+
         this.$router.push({ name: "dashboard" });
       } catch (error) {
         console.error(error);

--- a/src/ui/src/pages/auth/Login.vue
+++ b/src/ui/src/pages/auth/Login.vue
@@ -26,6 +26,12 @@ export default defineComponent({
             password: "",
         }
     },
+    mounted() {
+        this.$store.dispatch("requestConnector")
+        this.$store.dispatch("requestPool")
+        this.$store.dispatch("requestHost")
+        this.$store.dispatch("requestPolicy")
+    },
     methods: {
         async login() {
             try {

--- a/src/ui/src/pages/auth/Login.vue
+++ b/src/ui/src/pages/auth/Login.vue
@@ -73,45 +73,21 @@ export default defineComponent({
       password: "",
     };
   },
+  mounted() {
+    if (this.$store.state.token) {
+      this.$store.dispatch("requestConnector");
+      this.$store.dispatch("requestPool");
+      this.$store.dispatch("requestHost");
+      this.$store.dispatch("requestPolicy");
+      this.$store.dispatch("requestStorage");
+    }
+  },
   methods: {
     async submit() {
       if (this.$refs.form.validate()) {
         await this.login();
       }
     },
-<<<<<<< HEAD
-    mounted() {
-        this.$store.dispatch("requestConnector")
-        this.$store.dispatch("requestPool")
-        this.$store.dispatch("requestHost")
-        this.$store.dispatch("requestPolicy")
-    },
-    methods: {
-        async login() {
-            try {
-                const { data } = await axios.post(
-                    `${this.$store.state.endpoint.api}/api/v1/auth/password/login`,
-                    {
-                        username: process.env.VUE_APP_DEFAULT_USER_NAME,
-                        password: this.password
-                    },
-                    { headers: { 'Content-Type': 'application/json' } })
-                this.$store.dispatch('insertToken', data);
-                this.$store.commit('insertToken', data);
-                this.$vaToast.init({
-                    title: "Login",
-                    message: "You are logged in.",
-                    color: 'success',
-                })
-            } catch (error) {
-                console.error(error)
-                this.$vaToast.init({
-                    title: 'Login failed.',
-                    message: error?.response?.data?.detail ?? error,
-                    color: 'danger'
-                })
-            }
-=======
     async login() {
       try {
         const { data } = await axios.post(
@@ -130,6 +106,11 @@ export default defineComponent({
           message: "You are logged in.",
           color: "success",
         });
+        this.$store.dispatch("requestConnector");
+        this.$store.dispatch("requestPool");
+        this.$store.dispatch("requestHost");
+        this.$store.dispatch("requestPolicy");
+        this.$store.dispatch("requestStorage");
         this.$router.push({ name: "dashboard" });
       } catch (error) {
         console.error(error);
@@ -161,7 +142,6 @@ export default defineComponent({
             message: "Unable to reach the server.",
             color: "danger",
           });
->>>>>>> 3ea4a802cb8b13a9dbe7af75c1984a15646778cf
         }
       }
     },

--- a/src/ui/src/store/index.ts
+++ b/src/ui/src/store/index.ts
@@ -545,23 +545,29 @@ export default createStore({
     },
     async parseConnectors(context, { location }) {
       const token = context.state.token;
-      const { data } = await axios.get(
-        `${this.state.endpoint.api}${location}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      if (data.state === "PENDING" || data.state == "STARTED") {
-        setTimeout(() => {
-          context.dispatch("parseConnectors", {
-            location: location,
-          });
-        }, 2000);
-      } else {
-        context.commit("loadingConnector", true);
-        if (data.state === "SUCCESS") {
-          context.dispatch("updateConnectorsList", data.info);
-        } else if (data.state === "FAILURE") {
-          console.error(data.status);
+      try {
+        const { data } = await axios.get(
+          `${this.state.endpoint.api}${location}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        if (data.state === "PENDING" || data.state == "STARTED") {
+          setTimeout(() => {
+            context.dispatch("parseConnectors", {
+              location: location,
+            });
+          }, 2000);
+        } else {
+          context.commit("loadingConnector", true);
+          if (data.state === "SUCCESS") {
+            context.dispatch("updateConnectorsList", data.info);
+          } else if (data.state === "FAILURE") {
+            console.error(data.status);
+          }
         }
+      } catch (error) {
+        console.error("Error fetching connectors:", error);
+        context.commit("loadingConnector", false);
+        context.dispatch("updateConnectorsList", []);
       }
     },
     async updateConnector(context, { vm, connectorValues }) {


### PR DESCRIPTION
Remove automatic refresh for connectors, pools, hosts, and policies.

Initial data is now fetched once at login, with no further updates unless the user manually clicks the "Update" button for each resource (connectors, pools, hosts, policies). 

Also fixed a typo in the "Thursday" label and replaced the seeting icon in the VM list with an info icon and add a close button on the VMDetails page.

(Loading bars have been left in the code as comments in case we want to re-enable them later because they actually look pretty cool.)